### PR TITLE
SANTUARIO-555 Made order of output processors in a chain deterministic and intuitive

### DIFF
--- a/src/main/java/org/apache/xml/security/stax/ext/AbstractOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/AbstractOutputProcessor.java
@@ -51,6 +51,7 @@ public abstract class AbstractOutputProcessor implements OutputProcessor {
 
     protected XMLSecurityProperties securityProperties;
     protected XMLSecurityConstants.Action action;
+    protected int actionOrder = -1;
 
     private XMLSecurityConstants.Phase phase = XMLSecurityConstants.Phase.PROCESSING;
     private Set<Class<? extends OutputProcessor>> beforeProcessors;
@@ -66,8 +67,9 @@ public abstract class AbstractOutputProcessor implements OutputProcessor {
     }
 
     @Override
-    public void setAction(XMLSecurityConstants.Action action) {
+    public void setAction(XMLSecurityConstants.Action action, int actionOrder) {
         this.action = action;
+        this.actionOrder = actionOrder;
     }
 
     @Override
@@ -120,8 +122,14 @@ public abstract class AbstractOutputProcessor implements OutputProcessor {
         return securityProperties;
     }
 
+    @Override
     public XMLSecurityConstants.Action getAction() {
         return action;
+    }
+
+    @Override
+    public int getActionOrder() {
+        return actionOrder;
     }
 
     @Override

--- a/src/main/java/org/apache/xml/security/stax/ext/OutboundXMLSec.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/OutboundXMLSec.java
@@ -108,10 +108,11 @@ public class OutboundXMLSec {
         SecurePart signEntireRequestPart = null;
         SecurePart encryptEntireRequestPart = null;
 
+        int actionOrder = 0;
         for (XMLSecurityConstants.Action action : securityProperties.getActions()) {
             if (XMLSecurityConstants.SIGNATURE.equals(action)) {
                 XMLSignatureOutputProcessor signatureOutputProcessor = new XMLSignatureOutputProcessor();
-                initializeOutputProcessor(outputProcessorChain, signatureOutputProcessor, action);
+                initializeOutputProcessor(outputProcessorChain, signatureOutputProcessor, action, actionOrder++);
 
                 configureSignatureKeys(outboundSecurityContext);
                 List<SecurePart> signatureParts = securityProperties.getSignatureSecureParts();
@@ -141,7 +142,7 @@ public class OutboundXMLSec {
                 }
             } else if (XMLSecurityConstants.ENCRYPTION.equals(action)) {
                 XMLEncryptOutputProcessor encryptOutputProcessor = new XMLEncryptOutputProcessor();
-                initializeOutputProcessor(outputProcessorChain, encryptOutputProcessor, action);
+                initializeOutputProcessor(outputProcessorChain, encryptOutputProcessor, action, actionOrder++);
 
                 configureEncryptionKeys(outboundSecurityContext);
                 List<SecurePart> encryptionParts = securityProperties.getEncryptionSecureParts();
@@ -167,11 +168,11 @@ public class OutboundXMLSec {
         }
         if (output instanceof OutputStream) {
             final FinalOutputProcessor finalOutputProcessor = new FinalOutputProcessor((OutputStream) output, encoding);
-            initializeOutputProcessor(outputProcessorChain, finalOutputProcessor, null);
+            initializeOutputProcessor(outputProcessorChain, finalOutputProcessor, null, -1);
 
         } else if (output instanceof XMLStreamWriter) {
             final FinalOutputProcessor finalOutputProcessor = new FinalOutputProcessor((XMLStreamWriter) output);
-            initializeOutputProcessor(outputProcessorChain, finalOutputProcessor, null);
+            initializeOutputProcessor(outputProcessorChain, finalOutputProcessor, null, -1);
 
         } else {
             throw new IllegalArgumentException(output + " is not supported as output");
@@ -184,9 +185,9 @@ public class OutboundXMLSec {
         return streamWriter;
     }
 
-    private void initializeOutputProcessor(OutputProcessorChainImpl outputProcessorChain, OutputProcessor outputProcessor, XMLSecurityConstants.Action action) throws XMLSecurityException {
+    private void initializeOutputProcessor(OutputProcessorChainImpl outputProcessorChain, OutputProcessor outputProcessor, XMLSecurityConstants.Action action, int actionOrder) throws XMLSecurityException {
         outputProcessor.setXMLSecurityProperties(securityProperties);
-        outputProcessor.setAction(action);
+        outputProcessor.setAction(action, actionOrder);
         outputProcessor.init(outputProcessorChain);
     }
 

--- a/src/main/java/org/apache/xml/security/stax/ext/OutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/OutputProcessor.java
@@ -26,7 +26,25 @@ import java.util.Set;
 
 /**
  * This is the Interface which every OutputProcessor must implement.
- *
+ * The order of processors is defined by:
+ * <ol>
+ *     <li>{@link org.apache.xml.security.stax.ext.XMLSecurityConstants.Phase} (required)</li>
+ *     <li>
+ *         Action order (optional): allows grouping processors per action without them accidentally being reordered
+ *         incorrectly by processors of unrelated other action.
+ *         It helps grouping processors where before/after processor classes doesn't cut it:
+ *         signature-after-encryption is a valid use case, but also encryption-after-signature.
+ *         There is no absolute ordering of signature processors versus encryption processors.
+ *         That is where the action order comes in: whichever action comes first, it groups those processors together
+ *         such they can't accidentally get mingled in between processors of unrelated actions.
+ *         It's optional, if you set the action order to {@code -1} it will be ignored.
+ *         The action order thus only defines the order between two processors if <i>both</i> these processors have an
+ *         action order != {@code -1}.
+ *     </li>
+ *     <li>
+ *         Before/after processors based on processor classes (optional): this allows ordering of processors typically
+ *         belonging to a single action.</li>
+ * </ol>
  */
 public interface OutputProcessor {
 
@@ -40,9 +58,20 @@ public interface OutputProcessor {
     /**
      * setter for the Action after instantiation of the processor
      *
-     * @param action
+     * @param action The action this processor belongs to, possibly {@code null} for no particular action.
+     * @param actionOrder The action order of this processor, possibly {@code -1} for no particular action order.
      */
-    void setAction(XMLSecurityConstants.Action action);
+    void setAction(XMLSecurityConstants.Action action, int actionOrder);
+
+    /**
+     * @return The action to which this processor belongs, if any, else {@code null}.
+     */
+    XMLSecurityConstants.Action getAction();
+
+    /**
+     * @return The action order of this processor, or {@code -1}.
+     */
+    int getActionOrder();
 
     /**
      * Method will be called after setting the properties

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLEncryptOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLEncryptOutputProcessor.java
@@ -98,7 +98,7 @@ public class XMLEncryptOutputProcessor extends AbstractEncryptOutputProcessor {
                                     (OutboundSecurityToken)securityToken.getKeyWrappingToken()
                             );
                     internalEncryptionOutputProcessor.setXMLSecurityProperties(getSecurityProperties());
-                    internalEncryptionOutputProcessor.setAction(getAction());
+                    internalEncryptionOutputProcessor.setAction(getAction(), getActionOrder());
                     internalEncryptionOutputProcessor.init(outputProcessorChain);
 
                     setActiveInternalEncryptionOutputProcessor(internalEncryptionOutputProcessor);

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLSignatureEndingOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLSignatureEndingOutputProcessor.java
@@ -60,7 +60,7 @@ public class XMLSignatureEndingOutputProcessor extends AbstractSignatureEndingOu
 
         this.signedInfoProcessor = new SignedInfoProcessor(signatureAlgorithm, signatureId, xmlSecStartElement);
         this.signedInfoProcessor.setXMLSecurityProperties(getSecurityProperties());
-        this.signedInfoProcessor.setAction(getAction());
+        this.signedInfoProcessor.setAction(getAction(), getActionOrder());
         this.signedInfoProcessor.addAfterProcessor(XMLSignatureEndingOutputProcessor.class);
         this.signedInfoProcessor.init(outputProcessorChain);
         return this.signedInfoProcessor;

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLSignatureOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLSignatureOutputProcessor.java
@@ -53,7 +53,7 @@ public class XMLSignatureOutputProcessor extends AbstractSignatureOutputProcesso
         super.init(outputProcessorChain);
         XMLSignatureEndingOutputProcessor signatureEndingOutputProcessor = new XMLSignatureEndingOutputProcessor(this);
         signatureEndingOutputProcessor.setXMLSecurityProperties(getSecurityProperties());
-        signatureEndingOutputProcessor.setAction(getAction());
+        signatureEndingOutputProcessor.setAction(getAction(), getActionOrder());
         signatureEndingOutputProcessor.init(outputProcessorChain);
     }
 
@@ -103,7 +103,7 @@ public class XMLSignatureOutputProcessor extends AbstractSignatureOutputProcesso
                     getSignaturePartDefList().add(signaturePartDef);
                     internalSignatureOutputProcessor = new InternalSignatureOutputProcessor(signaturePartDef, xmlSecStartElement);
                     internalSignatureOutputProcessor.setXMLSecurityProperties(getSecurityProperties());
-                    internalSignatureOutputProcessor.setAction(getAction());
+                    internalSignatureOutputProcessor.setAction(getAction(), getActionOrder());
                     internalSignatureOutputProcessor.addAfterProcessor(XMLSignatureOutputProcessor.class);
                     internalSignatureOutputProcessor.addBeforeProcessor(XMLSignatureEndingOutputProcessor.class);
                     internalSignatureOutputProcessor.init(outputProcessorChain);

--- a/src/test/java/org/apache/xml/security/test/stax/OutputProcessorChainTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/OutputProcessorChainTest.java
@@ -19,6 +19,7 @@
 package org.apache.xml.security.test.stax;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.xml.stream.XMLStreamException;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  */
@@ -48,18 +50,32 @@ public class OutputProcessorChainTest {
                 this.getClass());
     }
 
-    abstract class AbstractOutputProcessor implements OutputProcessor {
+    static abstract class AbstractOutputProcessor implements OutputProcessor {
 
         private XMLSecurityConstants.Phase phase = XMLSecurityConstants.Phase.PROCESSING;
         private Set<Class<? extends OutputProcessor>> beforeProcessors = new HashSet<>();
         private Set<Class<? extends OutputProcessor>> afterProcessors = new HashSet<>();
+        private XMLSecurityConstants.Action action;
+        private int actionOrder = -1;
 
         @Override
         public void setXMLSecurityProperties(XMLSecurityProperties xmlSecurityProperties) {
         }
 
         @Override
-        public void setAction(XMLSecurityConstants.Action action) {
+        public void setAction(XMLSecurityConstants.Action action, int actionOrder) {
+            this.action = action;
+            this.actionOrder = actionOrder;
+        }
+
+        @Override
+        public XMLSecurityConstants.Action getAction() {
+            return action;
+        }
+
+        @Override
+        public int getActionOrder() {
+            return actionOrder;
         }
 
         @Override
@@ -289,5 +305,148 @@ public class OutputProcessorChainTest {
         assertEquals(outputProcessorChain.getProcessors().get(3), outputProcessor6);
         assertEquals(outputProcessorChain.getProcessors().get(4), outputProcessor5);
         assertEquals(outputProcessorChain.getProcessors().get(5), outputProcessor4);
+    }
+
+    @Test
+    public void testOrderOfProcessorsIsIndependentOfWhenTheyAreAddedToTheChain() {
+        AbstractOutputProcessor outputProcessor1 = new AbstractOutputProcessor() {
+        };
+        AbstractOutputProcessor outputProcessor2 = new AbstractOutputProcessor() {
+        };
+        AbstractOutputProcessor outputProcessor3 = new AbstractOutputProcessor() {
+        };
+        outputProcessor1.addBeforeProcessor(outputProcessor3.getClass());
+        outputProcessor2.addBeforeProcessor(outputProcessor3.getClass());
+        outputProcessor2.addAfterProcessor(outputProcessor1.getClass());
+        outputProcessor3.addAfterProcessor(outputProcessor1.getClass());
+
+        OutputProcessorChain outputProcessorChain1 = new OutputProcessorChainImpl(new OutboundSecurityContextImpl());
+        outputProcessorChain1.addProcessor(outputProcessor1);
+        outputProcessorChain1.addProcessor(outputProcessor2);
+        outputProcessorChain1.addProcessor(outputProcessor3);
+
+        List<OutputProcessor> processors1 = outputProcessorChain1.getProcessors();
+        assertEquals(outputProcessor1, processors1.get(0));
+        assertEquals(outputProcessor2, processors1.get(1));
+        assertEquals(outputProcessor3, processors1.get(2));
+
+        OutputProcessorChain outputProcessorChain2 = new OutputProcessorChainImpl(new OutboundSecurityContextImpl());
+        outputProcessorChain2.addProcessor(outputProcessor1);
+        outputProcessorChain2.addProcessor(outputProcessor3);
+        outputProcessorChain2.addProcessor(outputProcessor2);
+
+        List<OutputProcessor> processors2 = outputProcessorChain1.getProcessors();
+        assertEquals(outputProcessor1, processors2.get(0));
+        assertEquals(outputProcessor2, processors2.get(1));
+        assertEquals(outputProcessor3, processors2.get(2));
+    }
+
+    @Test
+    public void testActionOrderOfProcessorsGroupsThemTogether() {
+        AbstractOutputProcessor finalOutputProcessor = new AbstractOutputProcessor() {
+        };
+        finalOutputProcessor.setAction(null, -1);
+
+        AbstractOutputProcessor initialEncryptionOutputProcessor = new AbstractOutputProcessor() {
+        };
+        initialEncryptionOutputProcessor.setAction(XMLSecurityConstants.ENCRYPTION, 0);
+        initialEncryptionOutputProcessor.addBeforeProcessor(finalOutputProcessor.getClass());
+
+        AbstractOutputProcessor myEncryptionOutputProcessor = new AbstractOutputProcessor() {
+        };
+        myEncryptionOutputProcessor.setAction(XMLSecurityConstants.ENCRYPTION, 0);
+        myEncryptionOutputProcessor.addBeforeProcessor(finalOutputProcessor.getClass());
+        myEncryptionOutputProcessor.addAfterProcessor(initialEncryptionOutputProcessor.getClass());
+
+        AbstractOutputProcessor initialSignatureOutputProcessor = new AbstractOutputProcessor() {
+        };
+        initialSignatureOutputProcessor.setAction(XMLSecurityConstants.SIGNATURE, 1);
+        initialSignatureOutputProcessor.addBeforeProcessor(finalOutputProcessor.getClass());
+
+        AbstractOutputProcessor mySignatureOutputProcessor = new AbstractOutputProcessor() {
+        };
+        mySignatureOutputProcessor.setAction(XMLSecurityConstants.SIGNATURE, 1);
+        mySignatureOutputProcessor.addBeforeProcessor(finalOutputProcessor.getClass());
+        mySignatureOutputProcessor.addAfterProcessor(initialSignatureOutputProcessor.getClass());
+
+        OutputProcessorChain outputProcessorChain = new OutputProcessorChainImpl(new OutboundSecurityContextImpl());
+        outputProcessorChain.addProcessor(finalOutputProcessor);
+        outputProcessorChain.addProcessor(initialSignatureOutputProcessor);
+        outputProcessorChain.addProcessor(mySignatureOutputProcessor);
+        outputProcessorChain.addProcessor(myEncryptionOutputProcessor);
+        outputProcessorChain.addProcessor(initialEncryptionOutputProcessor);
+
+        List<OutputProcessor> outputProcessors = outputProcessorChain.getProcessors();
+        assertEquals(initialEncryptionOutputProcessor, outputProcessors.get(0));
+        assertEquals(myEncryptionOutputProcessor, outputProcessors.get(1));
+        assertEquals(initialSignatureOutputProcessor, outputProcessors.get(2));
+        assertEquals(mySignatureOutputProcessor, outputProcessors.get(3));
+        assertEquals(finalOutputProcessor, outputProcessors.get(4));
+    }
+
+    @Test
+    public void testConflictingOrderOfProcessors1() {
+        AbstractOutputProcessor outputProcessor1 = new AbstractOutputProcessor() {
+        };
+        outputProcessor1.setAction(null, -1);
+        AbstractOutputProcessor outputProcessor2 = new AbstractOutputProcessor() {
+        };
+        outputProcessor2.setAction(null, -1);
+        outputProcessor2.addBeforeProcessor(outputProcessor1.getClass());
+        outputProcessor2.addAfterProcessor(outputProcessor1.getClass());
+
+        OutputProcessorChain outputProcessorChain = new OutputProcessorChainImpl(new OutboundSecurityContextImpl());
+        outputProcessorChain.addProcessor(outputProcessor1);
+        assertThrows(IllegalArgumentException.class, () -> outputProcessorChain.addProcessor(outputProcessor2));
+
+        List<OutputProcessor> outputProcessors = outputProcessorChain.getProcessors();
+        assertEquals(1, outputProcessors.size());
+        assertEquals(outputProcessor1, outputProcessors.get(0));
+    }
+
+    @Test
+    public void testConflictingOrderOfProcessors2() {
+        AbstractOutputProcessor outputProcessor1 = new AbstractOutputProcessor() {
+        };
+        outputProcessor1.setAction(null, -1);
+        AbstractOutputProcessor outputProcessor2 = new AbstractOutputProcessor() {
+        };
+        outputProcessor2.setAction(null, -1);
+        outputProcessor1.addBeforeProcessor(outputProcessor2.getClass());
+        outputProcessor1.addAfterProcessor(outputProcessor2.getClass());
+
+        OutputProcessorChain outputProcessorChain = new OutputProcessorChainImpl(new OutboundSecurityContextImpl());
+        outputProcessorChain.addProcessor(outputProcessor1);
+        assertThrows(IllegalArgumentException.class, () -> outputProcessorChain.addProcessor(outputProcessor2));
+
+        List<OutputProcessor> outputProcessors = outputProcessorChain.getProcessors();
+        assertEquals(1, outputProcessors.size());
+        assertEquals(outputProcessor1, outputProcessors.get(0));
+    }
+
+    @Test
+    public void testConflictingOrderOfProcessors3() {
+        AbstractOutputProcessor outputProcessor1 = new AbstractOutputProcessor() {
+        };
+        outputProcessor1.setAction(null, -1);
+        AbstractOutputProcessor outputProcessor2 = new AbstractOutputProcessor() {
+        };
+        outputProcessor2.setAction(null, -1);
+        AbstractOutputProcessor outputProcessor3 = new AbstractOutputProcessor() {
+        };
+        outputProcessor3.setAction(null, -1);
+        outputProcessor1.addBeforeProcessor(outputProcessor2.getClass());
+        outputProcessor2.addBeforeProcessor(outputProcessor3.getClass());
+        outputProcessor3.addBeforeProcessor(outputProcessor1.getClass());
+
+        OutputProcessorChain outputProcessorChain = new OutputProcessorChainImpl(new OutboundSecurityContextImpl());
+        outputProcessorChain.addProcessor(outputProcessor1);
+        outputProcessorChain.addProcessor(outputProcessor2);
+        assertThrows(IllegalArgumentException.class, () -> outputProcessorChain.addProcessor(outputProcessor3));
+
+        List<OutputProcessor> outputProcessors = outputProcessorChain.getProcessors();
+        assertEquals(2, outputProcessors.size());
+        assertEquals(outputProcessor1, outputProcessors.get(0));
+        assertEquals(outputProcessor2, outputProcessors.get(1));
     }
 }

--- a/src/test/java/org/apache/xml/security/test/stax/XMLSecurityStreamWriterTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/XMLSecurityStreamWriterTest.java
@@ -220,7 +220,17 @@ public class XMLSecurityStreamWriterTest {
         }
 
         @Override
-        public void setAction(XMLSecurityConstants.Action action) {
+        public void setAction(XMLSecurityConstants.Action action, int actionOrder) {
+        }
+
+        @Override
+        public XMLSecurityConstants.Action getAction() {
+            return null;
+        }
+
+        @Override
+        public int getActionOrder() {
+            return -1;
         }
 
         @Override


### PR DESCRIPTION
Fixed bug in `OutputProcessorChainImpl.addProcessor` + simplified it to make it more intuitive.
Introduced `actionOrder` parameter to allow "grouping" of output processors that belong together.
One can now (in theory) chain multiple ENCRYPTION and SIGNATURE actions and their output processors will never get out of order or get mixed up between actions.