### PR TITLE
SANTUARIO-576 - SAML Validation fails in WildFly 19, Workaround

### DIFF
--- a/src/main/java/org/apache/xml/security/c14n/implementations/CanonicalizerBase.java
+++ b/src/main/java/org/apache/xml/security/c14n/implementations/CanonicalizerBase.java
@@ -240,7 +240,7 @@ public abstract class CanonicalizerBase extends CanonicalizerSpi {
 
             case Node.ELEMENT_NODE :
                 documentLevel = NODE_NOT_BEFORE_OR_AFTER_DOCUMENT_ELEMENT;
-                if (currentNode == excludeNode) {
+                if (excludeNode != null && currentNode.isEqualNode(excludeNode)) {
                     break;
                 }
                 Element currentElement = (Element)currentNode;


### PR DESCRIPTION
As mentioned in the JIRA issue, this is a workaround to SAML assertions run in an EAR within WildFly 19.