### PR TITLE
[SANTUARIO-586]sync JDK-8186958: better calculations for HashMap constructor parameter calculation

### DIFF
--- a/src/main/java/org/apache/jcp/xml/dsig/internal/dom/DOMXPathFilter2Transform.java
+++ b/src/main/java/org/apache/jcp/xml/dsig/internal/dom/DOMXPathFilter2Transform.java
@@ -103,7 +103,7 @@ public final class DOMXPathFilter2Transform extends ApacheTransform {
             if (attributes != null) {
                 int length = attributes.getLength();
                 Map<String, String> namespaceMap =
-                    new HashMap<>(length);
+                    new HashMap<>((int) Math.ceil(length / 0.75));
                 for (int i = 0; i < length; i++) {
                     Attr attr = (Attr)attributes.item(i);
                     String prefix = attr.getPrefix();

--- a/src/main/java/org/apache/jcp/xml/dsig/internal/dom/DOMXPathTransform.java
+++ b/src/main/java/org/apache/jcp/xml/dsig/internal/dom/DOMXPathTransform.java
@@ -71,7 +71,7 @@ public final class DOMXPathTransform extends ApacheTransform {
         if (attributes != null) {
             int length = attributes.getLength();
             Map<String, String> namespaceMap =
-                new HashMap<>(length);
+                new HashMap<>((int) Math.ceil(length / 0.75));
             for (int i = 0; i < length; i++) {
                 Attr attr = (Attr)attributes.item(i);
                 String prefix = attr.getPrefix();

--- a/src/main/java/org/apache/xml/security/stax/config/SecurityHeaderHandlerMapper.java
+++ b/src/main/java/org/apache/xml/security/stax/config/SecurityHeaderHandlerMapper.java
@@ -42,8 +42,9 @@ public final class SecurityHeaderHandlerMapper {
     protected static synchronized void init(SecurityHeaderHandlersType securityHeaderHandlersType,
             Class<?> callingClass) throws Exception {
         List<HandlerType> handlerList = securityHeaderHandlersType.getHandler();
-        handlerClassMap = new HashMap<>(handlerList.size() + 1);
-        for (int i = 0; i < handlerList.size(); i++) {
+        final int handlerListSize = handlerList.size();
+        handlerClassMap = new HashMap<>((int) Math.ceil(handlerListSize / 0.75));
+        for (int i = 0; i < handlerListSize; i++) {
             HandlerType handlerType = handlerList.get(i);
             QName qName = new QName(handlerType.getURI(), handlerType.getNAME());
             handlerClassMap.put(qName,

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/input/AbstractDecryptInputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/input/AbstractDecryptInputProcessor.java
@@ -125,8 +125,9 @@ public abstract class AbstractDecryptInputProcessor extends AbstractInputProcess
         this.keyInfoType = keyInfoType;
 
         final List<JAXBElement<ReferenceType>> dataReferenceOrKeyReference = referenceList.getDataReferenceOrKeyReference();
-        references = new HashMap<>(dataReferenceOrKeyReference.size() + 1); //+1 because the HashMap will resize otherwise
-        processedReferences = new ArrayList<>(dataReferenceOrKeyReference.size());
+        final int dataReferenceOrKeyReferenceSize = dataReferenceOrKeyReference.size();
+        references = new HashMap<>((int) Math.ceil(dataReferenceOrKeyReferenceSize / 0.75));
+        processedReferences = new ArrayList<>(dataReferenceOrKeyReferenceSize);
 
         Iterator<JAXBElement<ReferenceType>> referenceTypeIterator = dataReferenceOrKeyReference.iterator();
         while (referenceTypeIterator.hasNext()) {


### PR DESCRIPTION
In short, HashMap's int constructor accept capacity, but not size, which means if we wanna not make it resize, it is better to give it capacity calculated using size and default load factor 0.75

See also https://github.com/openjdk/jdk/pull/7928
