### PR TITLE
Replace cycles with iterator with enhanced-for

### DIFF
--- a/src/main/java/org/apache/xml/security/algorithms/implementations/ECDSAUtils.java
+++ b/src/main/java/org/apache/xml/security/algorithms/implementations/ECDSAUtils.java
@@ -23,7 +23,6 @@ import java.math.BigInteger;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.*;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public final class ECDSAUtils {
@@ -780,9 +779,7 @@ public final class ECDSAUtils {
             field = ecFieldF2m.getReductionPolynomial();
         }
 
-        Iterator<ECCurveDefinition> ecCurveDefinitionIterator = ecCurveDefinitions.iterator();
-        while (ecCurveDefinitionIterator.hasNext()) {
-            ECCurveDefinition ecCurveDefinition = ecCurveDefinitionIterator.next();
+        for (ECCurveDefinition ecCurveDefinition : ecCurveDefinitions) {
             String oid = ecCurveDefinition.equals(field, a, b, affineX, affineY, order, h);
             if (oid != null) {
                 return oid;
@@ -792,9 +789,7 @@ public final class ECDSAUtils {
     }
 
     public static ECCurveDefinition getECCurveDefinition(String oid) {
-        Iterator<ECCurveDefinition> ecCurveDefinitionIterator = ecCurveDefinitions.iterator();
-        while (ecCurveDefinitionIterator.hasNext()) {
-            ECCurveDefinition ecCurveDefinition = ecCurveDefinitionIterator.next();
+        for (ECCurveDefinition ecCurveDefinition : ecCurveDefinitions) {
             if (ecCurveDefinition.getOid().equals(oid)) {
                 return ecCurveDefinition;
             }

--- a/src/main/java/org/apache/xml/security/c14n/implementations/CanonicalizerBase.java
+++ b/src/main/java/org/apache/xml/security/c14n/implementations/CanonicalizerBase.java
@@ -23,7 +23,6 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -456,9 +455,8 @@ public abstract class CanonicalizerBase extends CanonicalizerSpi {
 
     protected int isVisibleDO(Node currentNode, int level) {
         if (nodeFilter != null) {
-            Iterator<NodeFilter> it = nodeFilter.iterator();
-            while (it.hasNext()) {
-                int i = it.next().isNodeIncludeDO(currentNode, level);
+            for (NodeFilter filter : nodeFilter) {
+                int i = filter.isNodeIncludeDO(currentNode, level);
                 if (i != 1) {
                     return i;
                 }
@@ -472,9 +470,8 @@ public abstract class CanonicalizerBase extends CanonicalizerSpi {
 
     protected int isVisibleInt(Node currentNode) {
         if (nodeFilter != null) {
-            Iterator<NodeFilter> it = nodeFilter.iterator();
-            while (it.hasNext()) {
-                int i = it.next().isNodeInclude(currentNode);
+            for (NodeFilter filter : nodeFilter) {
+                int i = filter.isNodeInclude(currentNode);
                 if (i != 1) {
                     return i;
                 }
@@ -488,9 +485,8 @@ public abstract class CanonicalizerBase extends CanonicalizerSpi {
 
     protected boolean isVisible(Node currentNode) {
         if (nodeFilter != null) {
-            Iterator<NodeFilter> it = nodeFilter.iterator();
-            while (it.hasNext()) {
-                if (it.next().isNodeInclude(currentNode) != 1) {
+            for (NodeFilter filter : nodeFilter) {
+                if (filter.isNodeInclude(currentNode) != 1) {
                     return false;
                 }
             }

--- a/src/main/java/org/apache/xml/security/c14n/implementations/NameSpaceSymbTable.java
+++ b/src/main/java/org/apache/xml/security/c14n/implementations/NameSpaceSymbTable.java
@@ -20,7 +20,6 @@ package org.apache.xml.security.c14n.implementations;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 
@@ -71,9 +70,7 @@ public class NameSpaceSymbTable {
      * @param result the list where to fill the unrendered xmlns definitions.
      **/
     public void getUnrenderedNodes(Collection<Attr> result) {
-        Iterator<NameSpaceSymbEntry> it = symb.entrySet().iterator();
-        while (it.hasNext()) {
-            NameSpaceSymbEntry n = it.next();
+        for (NameSpaceSymbEntry n : symb.entrySet()) {
             //put them rendered?
             if (!n.rendered && n.n != null) {
                 n = n.clone();

--- a/src/main/java/org/apache/xml/security/c14n/implementations/XmlAttrStack.java
+++ b/src/main/java/org/apache/xml/security/c14n/implementations/XmlAttrStack.java
@@ -125,20 +125,16 @@ class XmlAttrStack {
                 }
             }
             if (!baseAttrs.isEmpty()) {
-                Iterator<Attr> it = col.iterator();
                 String base = null;
                 Attr baseAttr = null;
-                while (it.hasNext()) {
-                    Attr n = it.next();
+                for (Attr n : col) {
                     if ("base".equals(n.getLocalName())) {
                         base = n.getValue();
                         baseAttr = n;
                         break;
                     }
                 }
-                it = baseAttrs.iterator();
-                while (it.hasNext()) {
-                    Attr n = it.next();
+                for (Attr n : baseAttrs) {
                     if (base == null) {
                         base = n.getValue();
                         baseAttr = n;
@@ -158,9 +154,7 @@ class XmlAttrStack {
         } else {
             for (; size >= 0; size--) {
                 e = levels.get(size);
-                Iterator<Attr> it = e.nodes.iterator();
-                while (it.hasNext()) {
-                    Attr n = it.next();
+                for (Attr n : e.nodes) {
                     if (!loa.containsKey(n.getName())) {
                         loa.put(n.getName(), n);
                     }

--- a/src/main/java/org/apache/xml/security/encryption/XMLCipher.java
+++ b/src/main/java/org/apache/xml/security/encryption/XMLCipher.java
@@ -3176,9 +3176,8 @@ public class XMLCipher {
                     );
                     result.appendChild(mgfElement);
                 }
-                Iterator<Element> itr = encryptionMethodInformation.iterator();
-                while (itr.hasNext()) {
-                    result.appendChild(itr.next());
+                for (Element element : encryptionMethodInformation) {
+                    result.appendChild(element);
                 }
 
                 return result;
@@ -3463,10 +3462,8 @@ public class XMLCipher {
                         EncryptionConstants.EncryptionSpecNS,
                         EncryptionConstants._TAG_REFERENCELIST
                     );
-                Iterator<Reference> eachReference = references.iterator();
-                while (eachReference.hasNext()) {
-                    Reference reference = eachReference.next();
-                    result.appendChild(((ReferenceImpl) reference).toElement());
+                for (Reference reference : references) {
+                    result.appendChild(((ReferenceImpl)reference).toElement());
                 }
                 return result;
             }

--- a/src/main/java/org/apache/xml/security/keys/keyresolver/implementations/RetrievalMethodResolver.java
+++ b/src/main/java/org/apache/xml/security/keys/keyresolver/implementations/RetrievalMethodResolver.java
@@ -27,7 +27,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
@@ -286,10 +285,8 @@ public class RetrievalMethodResolver extends KeyResolverSpi {
     }
 
     private static Element getDocumentElement(Set<Node> set) {
-        Iterator<Node> it = set.iterator();
         Element e = null;
-        while (it.hasNext()) {
-            Node currentNode = it.next();
+        for (Node currentNode : set) {
             if (currentNode != null && Node.ELEMENT_NODE == currentNode.getNodeType()) {
                 e = (Element) currentNode;
                 break;

--- a/src/main/java/org/apache/xml/security/signature/Manifest.java
+++ b/src/main/java/org/apache/xml/security/signature/Manifest.java
@@ -24,7 +24,6 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -352,11 +351,8 @@ public class Manifest extends SignatureElementProxy {
                             currentRef.dereferenceURIandPerformTransforms(null);
                         Set<Node> nl = signedManifestNodes.getNodeSet();
                         Manifest referencedManifest = null;
-                        Iterator<Node> nlIterator = nl.iterator();
 
-                        while (nlIterator.hasNext()) {
-                            Node n = nlIterator.next();
-
+                        for (Node n : nl) {
                             if (n.getNodeType() == Node.ELEMENT_NODE
                                 && ((Element) n).getNamespaceURI().equals(Constants.SignatureSpecNS)
                                 && ((Element) n).getLocalName().equals(Constants._TAG_MANIFEST)

--- a/src/main/java/org/apache/xml/security/stax/ext/InboundXMLSec.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/InboundXMLSec.java
@@ -36,7 +36,6 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -134,9 +133,7 @@ public class InboundXMLSec {
 
         List<InputProcessor> additionalInputProcessors = securityProperties.getInputProcessorList();
         if (!additionalInputProcessors.isEmpty()) {
-            Iterator<InputProcessor> inputProcessorIterator = additionalInputProcessors.iterator();
-            while (inputProcessorIterator.hasNext()) {
-                InputProcessor inputProcessor = inputProcessorIterator.next();
+            for (InputProcessor inputProcessor : additionalInputProcessors) {
                 inputProcessorChain.addProcessor(inputProcessor);
             }
         }

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/input/AbstractDecryptInputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/input/AbstractDecryptInputProcessor.java
@@ -33,7 +33,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -129,9 +128,8 @@ public abstract class AbstractDecryptInputProcessor extends AbstractInputProcess
         references = new HashMap<>((int) Math.ceil(dataReferenceOrKeyReferenceSize / 0.75));
         processedReferences = new ArrayList<>(dataReferenceOrKeyReferenceSize);
 
-        Iterator<JAXBElement<ReferenceType>> referenceTypeIterator = dataReferenceOrKeyReference.iterator();
-        while (referenceTypeIterator.hasNext()) {
-            ReferenceType referenceType = referenceTypeIterator.next().getValue();
+        for (JAXBElement<ReferenceType> referenceTypeJAXBElement : dataReferenceOrKeyReference) {
+            ReferenceType referenceType = referenceTypeJAXBElement.getValue();
             if (referenceType.getURI() == null) {
                 throw new XMLSecurityException("stax.emptyReferenceURI");
             }
@@ -600,9 +598,7 @@ public abstract class AbstractDecryptInputProcessor extends AbstractInputProcess
 
         //here we check if all references where processed.
         if (references != null) {
-            Iterator<Map.Entry<String, ReferenceType>> refEntryIterator = this.references.entrySet().iterator();
-            while (refEntryIterator.hasNext()) {
-                Map.Entry<String, ReferenceType> referenceTypeEntry = refEntryIterator.next();
+            for (Map.Entry<String, ReferenceType> referenceTypeEntry : this.references.entrySet()) {
                 if (!processedReferences.contains(referenceTypeEntry.getValue())) {
                     throw new XMLSecurityException("stax.encryption.unprocessedReferences");
                 }

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/input/AbstractSignatureReferenceVerifyInputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/input/AbstractSignatureReferenceVerifyInputProcessor.java
@@ -30,7 +30,6 @@ import java.security.NoSuchProviderException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -108,9 +107,7 @@ public abstract class AbstractSignatureReferenceVerifyInputProcessor extends Abs
         externalReferences = new ArrayList<>(referencesTypeList.size());
         processedReferences = new ArrayList<>(referencesTypeList.size());
 
-        Iterator<ReferenceType> referenceTypeIterator = referencesTypeList.iterator();
-        while (referenceTypeIterator.hasNext()) {
-            ReferenceType referenceType = referenceTypeIterator.next();
+        for (ReferenceType referenceType : referencesTypeList) {
             if (!doNotThrowExceptionForManifests && XMLSecurityConstants.NS_XMLDSIG_MANIFEST.equals(referenceType.getType())) {
                 throw new XMLSecurityException(
                         "secureProcessing.DoNotThrowExceptionForManifests"

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractSignatureEndingOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractSignatureEndingOutputProcessor.java
@@ -200,9 +200,7 @@ public abstract class AbstractSignatureEndingOutputProcessor extends AbstractBuf
 
         createEndElementAndOutputAsEvent(subOutputProcessorChain, XMLSecurityConstants.TAG_dsig_SignatureMethod);
 
-        Iterator<SignaturePartDef> signaturePartDefIterator = signaturePartDefList.iterator();
-        while (signaturePartDefIterator.hasNext()) {
-            SignaturePartDef signaturePartDef = signaturePartDefIterator.next();
+        for (SignaturePartDef signaturePartDef : signaturePartDefList) {
             String uriString;
             if (signaturePartDef.isExternalResource()) {
                 uriString = signaturePartDef.getSigRefId();
@@ -310,8 +308,7 @@ public abstract class AbstractSignatureEndingOutputProcessor extends AbstractBuf
 
                 Set<String> prefixSet = XMLSecurityUtils.getExcC14NInclusiveNamespacePrefixes(xmlSecStartElement, false);
                 StringBuilder prefixes = new StringBuilder();
-                for (Iterator<String> iterator = prefixSet.iterator(); iterator.hasNext(); ) {
-                    String prefix = iterator.next();
+                for (String prefix : prefixSet) {
                     if (prefixes.length() != 0) {
                         prefixes.append(' ');
                     }

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractSignatureOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractSignatureOutputProcessor.java
@@ -226,8 +226,7 @@ public abstract class AbstractSignatureOutputProcessor extends AbstractOutputPro
                         xmlSecStartElement, signaturePartDef.isExcludeVisibleC14Nprefixes()
                 );
                 StringBuilder prefixes = new StringBuilder();
-                for (Iterator<String> iterator = prefixSet.iterator(); iterator.hasNext(); ) {
-                    String prefix = iterator.next();
+                for (String prefix : prefixSet) {
                     if (prefixes.length() != 0) {
                         prefixes.append(' ');
                     }


### PR DESCRIPTION
There are few places in code where manual loop is used with Iterator to iterate over Collection.
Instead of manual cycles it's preferred to use enhanced-for cycle instead: it's less verbose, makes code easier to read and it's less error-prone.
It doesn't have any performance impact: java compiler generates similar code when compiling enhanced-for cycle. 