### PR TITLE
POM cleanup, fixed logging in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,13 +16,24 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache</groupId>
+        <artifactId>apache</artifactId>
+        <version>29</version>
+    </parent>
+
     <groupId>org.apache.santuario</groupId>
     <artifactId>xmlsec</artifactId>
-    <packaging>bundle</packaging>
-    <name>Apache XML Security for Java</name>
     <version>3.0.3-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+
+    <name>Apache XML Security for Java</name>
     <description>
         Apache XML Security for Java supports XML-Signature Syntax and Processing,
         W3C Recommendation 12 February 2002, and XML Encryption Syntax and
@@ -30,10 +41,18 @@
         the library supports the standard Java API JSR-105: XML Digital Signature APIs.
     </description>
     <url>https://santuario.apache.org/</url>
-    <issueManagement>
-        <system>JIRA</system>
-        <url>https://issues.apache.org/jira/browse/SANTUARIO</url>
-    </issueManagement>
+    <inceptionYear>2000</inceptionYear>
+    <organization>
+        <name>The Apache Software Foundation</name>
+        <url>https://www.apache.org/</url>
+    </organization>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
     <mailingLists>
         <mailingList>
             <name>Apache Santuario Developer List</name>
@@ -47,44 +66,172 @@
             </archive>
         </mailingList>
     </mailingLists>
-    <inceptionYear>2000</inceptionYear>
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/santuario-xml-security-java.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/santuario-xml-security-java.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf?p=santuario-xml-security-java.git;a=summary</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
+    <issueManagement>
+        <system>JIRA</system>
+        <url>https://issues.apache.org/jira/browse/SANTUARIO</url>
+    </issueManagement>
+    <distributionManagement>
+        <repository>
+            <id>apache.releases.https</id>
+            <name>Apache Release Distribution Repository</name>
+            <url>https://repository.apache.org/service/local/staging/deploy/maven2</url>
+        </repository>
+        <snapshotRepository>
+            <id>apache.snapshots.https</id>
+            <name>Apache Development Snapshot Repository</name>
+            <url>https://repository.apache.org/content/repositories/snapshots</url>
+            <uniqueVersion>false</uniqueVersion>
+        </snapshotRepository>
+    </distributionManagement>
 
-    <organization>
-        <name>The Apache Software Foundation</name>
-        <url>https://www.apache.org/</url>
-    </organization>
+    <properties>
+        <bcprov.version>1.73</bcprov.version>
+        <clirr.version>2.8</clirr.version>
+        <commons.codec.version>1.15</commons.codec.version>
+        <hamcrest.version>2.2</hamcrest.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
+        <junit.version>5.9.3</junit.version>
+        <log4j.version>2.20.0</log4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <xalan.version>2.7.2</xalan.version>
+        <xmlunit.version>2.9.1</xmlunit.version>
+        <xml.bind.api.version>3.0.1</xml.bind.api.version>
+        <xml.bind.impl.version>3.0.2</xml.bind.impl.version>
+        <woodstox.core.version>6.5.1</woodstox.core.version>
 
-    <parent>
-        <groupId>org.apache</groupId>
-        <artifactId>apache</artifactId>
-        <version>29</version>
-    </parent>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.outputTimestamp>2023-03-27T06:33:07Z</project.build.outputTimestamp>
+        <targetJdk>1.8</targetJdk>
+        <test.logging.level>info</test.logging.level>
+
+        <!-- Allow Clirr severity to be overriden by the command-line option -DminSeverity=level -->
+        <minSeverity>info</minSeverity>
+        <xmlsec.jaxb.context.class />
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${xml.bind.api.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.activation</groupId>
+                    <artifactId>jakarta.activation</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons.codec.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${woodstox.core.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-matchers</artifactId>
+            <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bcprov.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>${xalan.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${xml.bind.impl.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
-        <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
-        <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
+        <defaultGoal>install</defaultGoal>
+
         <resources>
             <resource>
-                <directory>src/main/java</directory>
-                <excludes>
-                    <exclude>**/*.java</exclude>
-                </excludes>
+                <directory>src/main/resources</directory>
             </resource>
             <resource>
-                <directory>src/main/resources</directory>
+                <!-- Because of src/main/java/org/apache/xml/security/resource/**/* -->
+                <directory>src/main/java</directory>
                 <excludes>
                     <exclude>**/*.java</exclude>
                 </excludes>
@@ -92,132 +239,77 @@
         </resources>
         <testResources>
             <testResource>
-                <directory>src/test/java</directory>
-                <excludes>
-                    <exclude>**/*.java</exclude>
-                </excludes>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>log4j2.xml</include>
+                </includes>
             </testResource>
             <testResource>
                 <directory>src/test/resources</directory>
                 <excludes>
-                    <exclude>**/*.java</exclude>
+                    <exclude>log4j2.xml</exclude>
                 </excludes>
+            </testResource>
+            <testResource>
+                <directory>src/test/java</directory>
+                <includes>
+                    <include>org/apache/xml/security/test/dom/resource/testvectors.zip</include>
+                </includes>
             </testResource>
         </testResources>
 
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.5.0</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <source>8</source>
+                        <attach>true</attach>
+                        <excludePackageNames>org.apache.xml.security.binding.*</excludePackageNames>
+                        <doclint>none</doclint>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>clirr-maven-plugin</artifactId>
+                    <version>${clirr.version}</version>
+                    <configuration>
+                        <minSeverity>${minSeverity}</minSeverity>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <configuration>
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <preparationGoals>clean install</preparationGoals>
+                        <goals>deploy</goals>
+                        <arguments>-Papache-release</arguments>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.15.0</version>
-                <configuration>
-                    <rulesets>
-                        <ruleset>${basedir}/etc/santuario-pmd-ruleset.xml</ruleset>
-                    </rulesets>
-                    <linkXRef>false</linkXRef>
-                    <sourceEncoding>UTF-8</sourceEncoding>
-                    <failOnViolation>true</failOnViolation>
-                    <verbose>true</verbose>
-                    <includeTests>false</includeTests>
-                    <targetJdk>${targetJdk}</targetJdk>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                 <groupId>org.gaul</groupId>
-                 <artifactId>modernizer-maven-plugin</artifactId>
-                 <version>2.6.0</version>
-                 <configuration>
-                     <javaVersion>${targetJdk}</javaVersion>
-                 </configuration>
-                 <executions>
-                     <execution>
-                         <id>modernizer-check</id>
-                         <phase>verify</phase>
-                         <goals>
-                             <goal>modernizer</goal>
-                         </goals>
-                     </execution>
-                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
-                <configuration>
-                    <source>${targetJdk}</source>
-                    <target>${targetJdk}</target>
-                    <compilerArgs>
-                        <arg>-XDcompilePolicy=simple</arg>
-                        <!-- TODO Disabled until JDK 14 is supported <arg>-Xplugin:ErrorProne</arg>-->
-                    </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>2.19.1</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-            
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
+                <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.3.0</version>
-                <executions>
-                    <execution>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>jar</goal>
-                            <goal>test-jar</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <testClassesDirectory>${project.build.directory}/test-classes</testClassesDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.8</version>
-                <extensions>true</extensions>
                 <configuration>
-                    <instructions>
-                        <Implementation-Title>Apache XML Security</Implementation-Title>
-                        <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
-                        <Implementation-Vendor-Id>org.apache</Implementation-Vendor-Id>
-                        <Implementation-Version>${project.version}</Implementation-Version>
-                        <Specification-Title>Apache XML Security</Specification-Title>
-                        <Specification-Vendor>The Apache Software Foundation</Specification-Vendor>
-                        <Specification-Version>${project.version}</Specification-Version>
-                        <Export-Package>
-                              org.apache.xml.security.*;version="${project.version}",
-                              org.apache.jcp.xml.dsig.internal.*;version="${project.version}",
-                        </Export-Package>
-                        <Import-Package>
-                              !org.apache.xml.security.*,
-                              !org.apache.jcp.xml.dsig.internal.*,
-                              org.slf4j.*;version="[1.7,3)",
-                              org.apache.commons.codec.*;version="[1.6,2)",
-                              org.apache.xml.dtm*;resolution:=optional;version="[2.7,3)",
-                              org.apache.xml.utils*;resolution:=optional;version="[2.7,3)",
-                              org.apache.xpath*;resolution:=optional;version="[2.7,3)",
-                              *
-                        </Import-Package>
-                        <Automatic-Module-Name>org.apache.santuario.xmlsec</Automatic-Module-Name>
-                    </instructions>
+                    <rules>
+                        <requireMavenVersion>
+                            <version>3.5</version>
+                        </requireMavenVersion>
+                    </rules>
                 </configuration>
             </plugin>
 
@@ -227,15 +319,13 @@
                 <version>0.15.0</version>
                 <executions>
                     <execution>
-                        <id>bindings</id>
+                        <id>generate-jaxb-sources</id>
                         <phase>generate-sources</phase>
                         <goals>
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <schemaDirectory>
-                                ${basedir}/src/main/resources/
-                            </schemaDirectory>
+                            <schemaDirectory>${basedir}/src/main/resources/</schemaDirectory>
                             <schemaIncludes>
                                 <schemaInclude>schemas/security-config.xsd</schemaInclude>
                                 <schemaInclude>bindings/schemas/exc-c14n.xsd</schemaInclude>
@@ -272,19 +362,156 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
                 <configuration>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <preparationGoals>clean install</preparationGoals>
-                    <goals>deploy</goals>
-                    <arguments>-Papache-release</arguments>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <source>${targetJdk}</source>
+                    <target>${targetJdk}</target>
+                    <compilerArgs>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <!-- TODO Disabled until JDK 14 is supported <arg>-Xplugin:ErrorProne</arg>-->
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.19.1</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Implementation-Title>Apache XML Security</Implementation-Title>
+                        <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
+                        <Implementation-Vendor-Id>org.apache</Implementation-Vendor-Id>
+                        <Implementation-Version>${project.version}</Implementation-Version>
+                        <Specification-Title>Apache XML Security</Specification-Title>
+                        <Specification-Vendor>The Apache Software Foundation</Specification-Vendor>
+                        <Specification-Version>${project.version}</Specification-Version>
+                        <Export-Package>
+                              org.apache.xml.security.*;version="${project.version}",
+                              org.apache.jcp.xml.dsig.internal.*;version="${project.version}",
+                        </Export-Package>
+                        <Import-Package>
+                              !org.apache.xml.security.*,
+                              !org.apache.jcp.xml.dsig.internal.*,
+                              org.slf4j.*;version="[1.7,3)",
+                              org.apache.commons.codec.*;version="[1.6,2)",
+                              *
+                        </Import-Package>
+                        <Automatic-Module-Name>org.apache.santuario.xmlsec</Automatic-Module-Name>
+                        <_noimportjava>true</_noimportjava>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.10</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-agent-for-unit-tests</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <reportFormat>brief</reportFormat>
+                    <!-- We need to reinitialize classes based on the configuration -->
+                    <reuseForks>false</reuseForks>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/PerformanceMemoryTest.java</exclude>
+                        <exclude>**/PerformanceTimingTest.java</exclude>
+                    </excludes>
+                    <!-- @{argLine} is generated by jacoco-prepare -->
+                    <argLine>@{argLine}</argLine>
+                    <systemPropertyVariables>
+                        <product.version>${project.version}</product.version>
+                        <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                        <!--<jakarta.xml.bind.JAXBContext>${xmlsec.jaxb.context.class}</jakarta.xml.bind.JAXBContext>-->
+                        <javax.xml.accessExternalDTD>file</javax.xml.accessExternalDTD>
+                        <org.apache.xml.security.securerandom.algorithm>SHA1PRNG</org.apache.xml.security.securerandom.algorithm>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                 <groupId>org.gaul</groupId>
+                 <artifactId>modernizer-maven-plugin</artifactId>
+                 <version>2.6.0</version>
+                 <configuration>
+                     <javaVersion>${targetJdk}</javaVersion>
+                 </configuration>
+                 <executions>
+                     <execution>
+                         <id>modernizer-check</id>
+                         <phase>verify</phase>
+                         <goals>
+                             <goal>modernizer</goal>
+                         </goals>
+                     </execution>
+                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.15.0</version>
+                <configuration>
+                    <rulesets>
+                        <ruleset>${basedir}/etc/santuario-pmd-ruleset.xml</ruleset>
+                    </rulesets>
+                    <linkXRef>false</linkXRef>
+                    <sourceEncoding>UTF-8</sourceEncoding>
+                    <failOnViolation>true</failOnViolation>
+                    <verbose>true</verbose>
+                    <includeTests>false</includeTests>
+                    <targetJdk>${targetJdk}</targetJdk>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pmd-verify</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.5.0</version>
+                 <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -292,81 +519,22 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <attach>true</attach>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.5.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
-
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <source>8</source>
-                        <attach>true</attach>
-                        <excludePackageNames>org.apache.xml.security.binding.*</excludePackageNames>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>clirr-maven-plugin</artifactId>
-                    <version>${clirr.version}</version>
-                    <configuration>
-                        <minSeverity>${minSeverity}</minSeverity>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.3.0</version>
-                    <configuration>
-                        <rules>
-                            <requireMavenVersion>
-                                <version>3.5</version>
-                            </requireMavenVersion>
-                        </rules>
-                    </configuration>
-                </plugin>
-
-            </plugins>
-        </pluginManagement>
-
-        <defaultGoal>install</defaultGoal>
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>clirr-maven-plugin</artifactId>
+                <version>${clirr.version}</version>
+                <configuration>
+                    <minSeverity>${minSeverity}</minSeverity>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <profiles>
         <profile>
@@ -380,11 +548,9 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                     </plugin>
                 </plugins>
@@ -404,7 +570,7 @@
             </properties>
         </profile>
         <profile>
-            <id>jdk18</id>
+            <id>jdk8</id>
             <activation>
                 <jdk>1.8</jdk>
             </activation>
@@ -412,16 +578,6 @@
                 <pluginManagement>
                     <plugins>
                         <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <additionalJOptions>
-                                    <additionalJOption>-Xdoclint:none</additionalJOption>
-                                </additionalJOptions>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-compiler-plugin</artifactId>
                             <configuration>
                                 <fork>true</fork>
@@ -430,37 +586,12 @@
                                 </compilerArgs>
                             </configuration>
                         </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <version>3.0.0</version>
-                            <configuration>
-                                <reportFormat>brief</reportFormat>
-                                <useFile>false</useFile>
-                                <childDelegation>false</childDelegation>
-                                <reuseForks>false</reuseForks>
-                                <includes>
-                                    <include>**/*Test.java</include>
-                                </includes>
-                                <excludes>
-                                    <exclude>**/PerformanceMemoryTest.java</exclude>
-                                    <exclude>**/PerformanceTimingTest.java</exclude>
-                                </excludes>
-                                <systemPropertyVariables>
-                                    <product.version>${project.version}</product.version>
-                                    <!--<jakarta.xml.bind.JAXBContext>${xmlsec.jaxb.context.class}</jakarta.xml.bind.JAXBContext>-->
-                                    <log4j.configurationFile>src/test/resources/log4j2.xml</log4j.configurationFile>
-                                    <javax.xml.accessExternalDTD>file</javax.xml.accessExternalDTD>
-                                    <org.apache.xml.security.securerandom.algorithm>SHA1PRNG</org.apache.xml.security.securerandom.algorithm>
-                                </systemPropertyVariables>
-                            </configuration>
-                        </plugin>
                     </plugins>
                 </pluginManagement>
             </build>
          </profile>
          <profile>
-            <id>jdk19-plus</id>
+            <id>jdk9-plus</id>
             <activation>
                 <jdk>[9,)</jdk>
             </activation>
@@ -468,38 +599,9 @@
                 <pluginManagement>
                     <plugins>
                         <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <additionalJOptions>
-                                    <additionalJOption>-Xdoclint:none</additionalJOption>
-                                </additionalJOptions>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-surefire-plugin</artifactId>
-                            <version>3.0.0</version>
                             <configuration>
-                                <reportFormat>brief</reportFormat>
-                                <useFile>false</useFile>
-                                <childDelegation>false</childDelegation>
-                                <reuseForks>false</reuseForks>
-                                <includes>
-                                    <include>**/*Test.java</include>
-                                </includes>
-                                <excludes>
-                                    <exclude>**/PerformanceMemoryTest.java</exclude>
-                                    <exclude>**/PerformanceTimingTest.java</exclude>
-                                </excludes>
-                                <argLine>-Xmx2000m --add-opens java.base/java.lang.reflect=ALL-UNNAMED</argLine>
-                                <systemPropertyVariables>
-                                    <product.version>${project.version}</product.version>
-                                    <log4j.configurationFile>src/test/resources/log4j2.xml</log4j.configurationFile>
-                                    <!--<jakarta.xml.bind.JAXBContext>${xmlsec.jaxb.context.class}</jakarta.xml.bind.JAXBContext>-->
-                                    <javax.xml.accessExternalDTD>file</javax.xml.accessExternalDTD>
-                                    <org.apache.xml.security.securerandom.algorithm>SHA1PRNG</org.apache.xml.security.securerandom.algorithm>
-                                </systemPropertyVariables>
+                                <argLine>--add-opens java.base/java.lang.reflect=ALL-UNNAMED @{argLine}</argLine>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -508,159 +610,4 @@
          </profile>
 
     </profiles>
-
-    <properties>
-        <slf4j.version>2.0.7</slf4j.version>
-        <xalan.version>2.7.2</xalan.version>
-        <junit.version>5.9.3</junit.version>
-        <log4j.version>2.20.0</log4j.version>
-        <bcprov.version>1.73</bcprov.version>
-        <hamcrest.version>2.2</hamcrest.version>
-        <xmlunit.version>2.9.1</xmlunit.version>
-        <commons.codec.version>1.15</commons.codec.version>
-        <woodstox.core.version>6.5.1</woodstox.core.version>
-        <jetty.version>9.4.51.v20230217</jetty.version>
-        <xml.bind.api.version>3.0.1</xml.bind.api.version>
-        <xml.bind.impl.version>3.0.2</xml.bind.impl.version>
-        <xmlsec.jaxb.context.class />
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <targetJdk>1.8</targetJdk>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <clirr.version>2.8</clirr.version>
-        <!-- Allow Clirr severity to be overriden by the command-line option -DminSeverity=level -->
-        <minSeverity>info</minSeverity>
-        <project.build.outputTimestamp>2023-03-27T06:33:07Z</project.build.outputTimestamp>
-    </properties>
-    
-    <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${xml.bind.api.version}</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>jakarta.activation</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>${commons.codec.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.woodstox</groupId>
-            <artifactId>woodstox-core</artifactId>
-            <version>${woodstox.core.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-core</artifactId>
-            <version>${xmlunit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-matchers</artifactId>
-            <version>${xmlunit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <version>${xalan.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-            <version>${bcprov.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>${xml.bind.impl.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
-    <distributionManagement>
-        <repository>
-            <id>apache.releases.https</id>
-            <name>Apache Release Distribution Repository</name>
-            <url>https://repository.apache.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-            <id>apache.snapshots.https</id>
-            <name>Apache Development Snapshot Repository</name>
-            <url>https://repository.apache.org/content/repositories/snapshots</url>
-            <uniqueVersion>false</uniqueVersion>
-        </snapshotRepository>
-    </distributionManagement>
-
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>clirr-maven-plugin</artifactId>
-                <version>${clirr.version}</version>
-                <configuration>
-                    <minSeverity>${minSeverity}</minSeverity>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
 </project>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<Configuration status="info" name="Apache Santuario" packages="">
+<Configuration status="info" name="Apache Santuario">
     <Appenders>
-        <File name="LOG" fileName="target/logging.log">
+        <File name="LOG" fileName="${project.build.directory}/logging.log">
             <PatternLayout>
                 <Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
             </PatternLayout>
@@ -11,7 +11,7 @@
         </Async>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="${test.logging.level}">
             <AppenderRef ref="Async"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
- Keeping standard order from XSD
- Reverted SLF4J version update in 59b9ae1188469825709e116615c0353cae640c77
  - fixes warnings of logging in tests
  - was a breaking change
- Removed deprecated "packages" attribute from LOG4J2 configuration
- Fixed logging output to the logging.log file
- Better use the output path for resources (test logging config)
- Fixed JaCoCo configuration
- Removed unused packages from Felix plugin config
- Updated maven surefire plugin
- Removed Xmx2000m (workaround for old leaks?)

This PR is a partial step to #101 which will be rebased after the merge of this.