### PR TITLE
Make `providerName` in `JCEMapper.java` Thread-safe

### DIFF
--- a/src/main/java/org/apache/xml/security/algorithms/JCEMapper.java
+++ b/src/main/java/org/apache/xml/security/algorithms/JCEMapper.java
@@ -37,7 +37,7 @@ public class JCEMapper {
 
     private static Map<String, Algorithm> algorithmsMap = new ConcurrentHashMap<>();
 
-    private static String providerName;
+    private static ThreadLocal<String> providerName = new ThreadLocal<>();
 
     /**
      * Method register
@@ -434,7 +434,7 @@ public class JCEMapper {
      * @return the default providerId.
      */
     public static String getProviderId() {
-        return providerName;
+        return providerName.get();
     }
 
     /**
@@ -445,7 +445,7 @@ public class JCEMapper {
      */
     public static void setProviderId(String provider) {
         JavaUtils.checkRegisterPermission();
-        providerName = provider;
+        providerName.set(provider);
     }
 
     /**


### PR DESCRIPTION
- make static `providerName` to be a `ThreadLocal`

The problem was that, in a concurrent application, if you use provider “A” to sign messages and a different provider (provider “B”) for signature verification, then parallel threads can overwrite the configured provider of each other. 