### PR TITLE
Make provider in JCEMapper.java Thread-safe

### DIFF
--- a/src/main/java/org/apache/xml/security/algorithms/JCEMapper.java
+++ b/src/main/java/org/apache/xml/security/algorithms/JCEMapper.java
@@ -37,7 +37,9 @@ public class JCEMapper {
 
     private static Map<String, Algorithm> algorithmsMap = new ConcurrentHashMap<>();
 
-    private static String providerName;
+    private static String globalProviderName;
+
+    private static final ThreadLocal<String> threadSpecificProviderName = new ThreadLocal<>();
 
     /**
      * Method register
@@ -434,7 +436,10 @@ public class JCEMapper {
      * @return the default providerId.
      */
     public static String getProviderId() {
-        return providerName;
+        if (threadSpecificProviderName.get() != null) {
+            return threadSpecificProviderName.get();
+        }
+        return globalProviderName;
     }
 
     /**
@@ -445,7 +450,18 @@ public class JCEMapper {
      */
     public static void setProviderId(String provider) {
         JavaUtils.checkRegisterPermission();
-        providerName = provider;
+        globalProviderName = provider;
+    }
+
+    /**
+     * Sets the default Provider for this thread to obtain the security algorithms
+     * @param threadSpecificProviderName the default providerId.
+     * @throws SecurityException if a security manager is installed and the
+     *    caller does not have permission to register the JCE algorithm
+     */
+    public static void setThreadSpecificProviderName(String threadSpecificProviderName) {
+        JavaUtils.checkRegisterPermission();
+        JCEMapper.threadSpecificProviderName.set(threadSpecificProviderName);
     }
 
     /**


### PR DESCRIPTION
-Introduce a ThreadLocal provider configuration that can hold a thread specific default provider. This way concurrency on the default provider can be avoided.


Based on the discussion and points here: https://github.com/apache/santuario-xml-security-java/pull/184#issuecomment-1607276879, I opened this PR to make the default provider configurable per thread. Also this solution is backward compatible, so this should not break any existing integrations.