### PR TITLE
SANTUARIO-604: Use PSSParameterSpec for RSASSA-PSS without parameters SignatureMethod URIs

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -11,4 +11,4 @@ The development of this software was partly funded by the European
 Commission in the <WebSig> project in the ISIS Programme. 
 
 This product contains software that is
-copyright (c) 2021, Oracle and/or its affiliates.
+copyright (c) 2021, 2023, Oracle and/or its affiliates.

--- a/src/main/java/org/apache/jcp/xml/dsig/internal/dom/DOMSignatureMethod.java
+++ b/src/main/java/org/apache/jcp/xml/dsig/internal/dom/DOMSignatureMethod.java
@@ -378,6 +378,11 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         byte[] preVerifyFormat(Key key, byte[] sig) {
             return sig;
         }
+
+        @Override
+        Type getAlgorithmType() {
+            return Type.RSA;
+        }
     }
 
     abstract static class AbstractRSAPSSSignatureMethod
@@ -408,9 +413,7 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
                 }
                 return s;
             } catch (NoSuchAlgorithmException nsae) {
-                return (p == null)
-                        ? Signature.getInstance(getJCAAlgorithm())
-                        : Signature.getInstance(getJCAAlgorithm(), p);
+                return super.getSignature(p);
             }
         }
     }
@@ -504,6 +507,11 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
                 return sig;
             }
         }
+
+        @Override
+        Type getAlgorithmType() {
+            return Type.DSA;
+        }
     }
 
     abstract static class AbstractECDSASignatureMethod
@@ -545,6 +553,11 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
                 return sig;
             }
         }
+
+        @Override
+        Type getAlgorithmType() {
+            return Type.ECDSA;
+        }
     }
 
     abstract static class AbstractEDDSASignatureMethod
@@ -578,6 +591,10 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
             return sig;
         }
 
+        @Override
+        Type getAlgorithmType() {
+            return Type.EDDSA;
+        }
     }
 
     static final class SHA1withRSA extends AbstractRSASignatureMethod {
@@ -595,10 +612,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         @Override
         String getJCAAlgorithm() {
             return "SHA1withRSA";
-        }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
         }
     }
 
@@ -618,10 +631,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         String getJCAAlgorithm() {
             return "SHA224withRSA";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA256withRSA extends AbstractRSASignatureMethod {
@@ -639,10 +648,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         @Override
         String getJCAAlgorithm() {
             return "SHA256withRSA";
-        }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
         }
     }
 
@@ -662,10 +667,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         String getJCAAlgorithm() {
             return "SHA384withRSA";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA512withRSA extends AbstractRSASignatureMethod {
@@ -683,10 +684,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         @Override
         String getJCAAlgorithm() {
             return "SHA512withRSA";
-        }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
         }
     }
 
@@ -706,15 +703,11 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         String getJCAAlgorithm() {
             return "RIPEMD160withRSA";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA1withRSAandMGF1 extends AbstractRSAPSSSignatureMethod {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA1_MGF1_PARAMS
                 = new PSSParameterSpec("SHA-1", "MGF1", MGF1ParameterSpec.SHA1,
                 20, PSSParameterSpec.TRAILER_FIELD_BC);
 
@@ -731,21 +724,17 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         }
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA1_MGF1_PARAMS;
         }
         @Override
         String getJCAAlgorithm() {
             return "SHA1withRSAandMGF1";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA224withRSAandMGF1 extends AbstractRSAPSSSignatureMethod {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA224_MGF1_PARAMS
                 = new PSSParameterSpec("SHA-224", "MGF1", MGF1ParameterSpec.SHA224,
                 28, PSSParameterSpec.TRAILER_FIELD_BC);
 
@@ -762,21 +751,17 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         }
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA224_MGF1_PARAMS;
         }
         @Override
         String getJCAAlgorithm() {
             return "SHA224withRSAandMGF1";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA256withRSAandMGF1 extends AbstractRSAPSSSignatureMethod {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA256_MGF1_PARAMS
                 = new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256,
                 32, PSSParameterSpec.TRAILER_FIELD_BC);
 
@@ -793,21 +778,17 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         }
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA256_MGF1_PARAMS;
         }
         @Override
         String getJCAAlgorithm() {
             return "SHA256withRSAandMGF1";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA384withRSAandMGF1 extends AbstractRSAPSSSignatureMethod {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA384_MGF1_PARAMS
                 = new PSSParameterSpec("SHA-384", "MGF1", MGF1ParameterSpec.SHA384,
                 48, PSSParameterSpec.TRAILER_FIELD_BC);
 
@@ -824,21 +805,17 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         }
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA384_MGF1_PARAMS;
         }
         @Override
         String getJCAAlgorithm() {
             return "SHA384withRSAandMGF1";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA512withRSAandMGF1 extends AbstractRSAPSSSignatureMethod {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA512_MGF1_PARAMS
                 = new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512,
                 64, PSSParameterSpec.TRAILER_FIELD_BC);
 
@@ -855,21 +832,17 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         }
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA512_MGF1_PARAMS;
         }
         @Override
         String getJCAAlgorithm() {
             return "SHA512withRSAandMGF1";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA3_224withRSAandMGF1 extends AbstractRSAPSSSignatureMethod {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA3_224_MGF1_PARAMS
                 = new PSSParameterSpec("SHA3-224", "MGF1",
                 new MGF1ParameterSpec("SHA3-224"), 28,
                 PSSParameterSpec.TRAILER_FIELD_BC);
@@ -887,21 +860,17 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         }
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA3_224_MGF1_PARAMS;
         }
         @Override
         String getJCAAlgorithm() {
             return "SHA3-224withRSAandMGF1";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA3_256withRSAandMGF1 extends AbstractRSAPSSSignatureMethod {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA3_256_MGF1_PARAMS
                 = new PSSParameterSpec("SHA3-256", "MGF1",
                 new MGF1ParameterSpec("SHA3-256"), 32,
                 PSSParameterSpec.TRAILER_FIELD_BC);
@@ -919,21 +888,17 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         }
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA3_256_MGF1_PARAMS;
         }
         @Override
         String getJCAAlgorithm() {
             return "SHA3-256withRSAandMGF1";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA3_384withRSAandMGF1 extends AbstractRSAPSSSignatureMethod {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA3_384_MGF1_PARAMS
                 = new PSSParameterSpec("SHA3-384", "MGF1",
                 new MGF1ParameterSpec("SHA3-384"), 48,
                 PSSParameterSpec.TRAILER_FIELD_BC);
@@ -951,21 +916,17 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         }
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA3_384_MGF1_PARAMS;
         }
         @Override
         String getJCAAlgorithm() {
             return "SHA3-384withRSAandMGF1";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
-        }
     }
 
     static final class SHA3_512withRSAandMGF1 extends AbstractRSAPSSSignatureMethod {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA3_512_MGF1_PARAMS
                 = new PSSParameterSpec("SHA3-512", "MGF1",
                 new MGF1ParameterSpec("SHA3-512"), 64,
                 PSSParameterSpec.TRAILER_FIELD_BC);
@@ -983,15 +944,11 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         }
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA3_512_MGF1_PARAMS;
         }
         @Override
         String getJCAAlgorithm() {
             return "SHA3-512withRSAandMGF1";
-        }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
         }
     }
 
@@ -1010,10 +967,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         @Override
         String getJCAAlgorithm() {
             return "RIPEMD160withRSAandMGF1";
-        }
-        @Override
-        Type getAlgorithmType() {
-            return Type.RSA;
         }
     }
 
@@ -1037,10 +990,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         String getJCAFallbackAlgorithm() {
             return "SHA1withDSA";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.DSA;
-        }
     }
 
     static final class SHA256withDSA extends AbstractDSASignatureMethod {
@@ -1062,10 +1011,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         @Override
         String getJCAFallbackAlgorithm() {
             return "SHA256withDSA";
-        }
-        @Override
-        Type getAlgorithmType() {
-            return Type.DSA;
         }
     }
 
@@ -1089,10 +1034,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         String getJCAFallbackAlgorithm() {
             return "SHA1withECDSA";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.ECDSA;
-        }
     }
 
     static final class SHA224withECDSA extends AbstractECDSASignatureMethod {
@@ -1114,10 +1055,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         @Override
         String getJCAFallbackAlgorithm() {
             return "SHA224withECDSA";
-        }
-        @Override
-        Type getAlgorithmType() {
-            return Type.ECDSA;
         }
     }
 
@@ -1141,10 +1078,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         String getJCAFallbackAlgorithm() {
             return "SHA256withECDSA";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.ECDSA;
-        }
     }
 
     static final class SHA384withECDSA extends AbstractECDSASignatureMethod {
@@ -1166,10 +1099,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         @Override
         String getJCAFallbackAlgorithm() {
             return "SHA384withECDSA";
-        }
-        @Override
-        Type getAlgorithmType() {
-            return Type.ECDSA;
         }
     }
 
@@ -1193,10 +1122,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         String getJCAFallbackAlgorithm() {
             return "SHA512withECDSA";
         }
-        @Override
-        Type getAlgorithmType() {
-            return Type.ECDSA;
-        }
     }
 
     static final class RIPEMD160withECDSA extends AbstractECDSASignatureMethod {
@@ -1218,10 +1143,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         @Override
         String getJCAFallbackAlgorithm() {
             return "RIPEMD160withECDSA";
-        }
-        @Override
-        Type getAlgorithmType() {
-            return Type.ECDSA;
         }
     }
 
@@ -1245,11 +1166,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         String getJCAAlgorithm() {
             return "Ed25519";
         }
-
-        @Override
-        Type getAlgorithmType() {
-            return Type.EDDSA;
-        }
     }
 
     static final class EDDSA_ED448 extends AbstractEDDSASignatureMethod {
@@ -1270,11 +1186,6 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
         @Override
         String getJCAAlgorithm() {
             return "Ed448";
-        }
-
-        @Override
-        Type getAlgorithmType() {
-            return Type.EDDSA;
         }
     }
 }

--- a/src/main/java/org/apache/jcp/xml/dsig/internal/dom/DOMXMLSignatureFactory.java
+++ b/src/main/java/org/apache/jcp/xml/dsig/internal/dom/DOMXMLSignatureFactory.java
@@ -303,6 +303,14 @@ public final class DOMXMLSignatureFactory extends XMLSignatureFactory {
             return new DOMSignatureMethod.SHA384withRSAandMGF1(params);
         } else if (algorithm.equals(DOMSignatureMethod.RSA_SHA512_MGF1)) {
             return new DOMSignatureMethod.SHA512withRSAandMGF1(params);
+        } else if (algorithm.equals(DOMSignatureMethod.RSA_SHA3_224_MGF1)) {
+            return new DOMSignatureMethod.SHA3_224withRSAandMGF1(params);
+        } else if (algorithm.equals(DOMSignatureMethod.RSA_SHA3_256_MGF1)) {
+            return new DOMSignatureMethod.SHA3_256withRSAandMGF1(params);
+        } else if (algorithm.equals(DOMSignatureMethod.RSA_SHA3_384_MGF1)) {
+            return new DOMSignatureMethod.SHA3_384withRSAandMGF1(params);
+        } else if (algorithm.equals(DOMSignatureMethod.RSA_SHA3_512_MGF1)) {
+            return new DOMSignatureMethod.SHA3_512withRSAandMGF1(params);
         } else if (algorithm.equals(DOMRSAPSSSignatureMethod.RSA_PSS)) {
             return new DOMRSAPSSSignatureMethod.RSAPSS(params);
         } else if (algorithm.equals(DOMSignatureMethod.RSA_RIPEMD160_MGF1)) {

--- a/src/main/java/org/apache/xml/security/algorithms/implementations/SignatureBaseRSA.java
+++ b/src/main/java/org/apache/xml/security/algorithms/implementations/SignatureBaseRSA.java
@@ -60,20 +60,25 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
 
     public SignatureBaseRSA(Provider provider) throws XMLSignatureException {
         String algorithmID = JCEMapper.translateURItoJCEID(this.engineGetURI());
-        LOG.log(Level.DEBUG, "Created SignatureRSA using {0}", algorithmID);
+        this.signatureAlgorithm = getSignature(provider, algorithmID);
+        LOG.log(Level.DEBUG, "Created SignatureRSA using {0} and provider {1}",
+            algorithmID, signatureAlgorithm.getProvider());
+    }
 
+    Signature getSignature(Provider provider, String algorithmID)
+        throws XMLSignatureException {
         try {
             if (provider == null) {
                 String providerId = JCEMapper.getProviderId();
                 if (providerId == null) {
-                    this.signatureAlgorithm = Signature.getInstance(algorithmID);
+                    return Signature.getInstance(algorithmID);
 
                 } else {
-                    this.signatureAlgorithm = Signature.getInstance(algorithmID, providerId);
+                    return Signature.getInstance(algorithmID, providerId);
                 }
 
             } else {
-                this.signatureAlgorithm = Signature.getInstance(algorithmID, provider);
+                return Signature.getInstance(algorithmID, provider);
             }
 
         } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
@@ -364,10 +369,53 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
         }
     }
 
+    public abstract static class SignatureBaseRSAPSS extends SignatureBaseRSA {
+
+        public SignatureBaseRSAPSS() throws XMLSignatureException {
+            super();
+        }
+
+        public SignatureBaseRSAPSS(Provider provider) throws XMLSignatureException {
+            super(provider);
+        }
+
+        @Override
+        Signature getSignature(Provider provider, String algorithmID)
+            throws XMLSignatureException {
+            try {
+                Signature sig;
+                if (provider == null) {
+                    String providerId = JCEMapper.getProviderId();
+                    if (providerId == null) {
+                        sig = Signature.getInstance("RSASSA-PSS");
+                    } else {
+                        sig = Signature.getInstance("RSASSA-PSS", providerId);
+                    }
+                } else {
+                    sig = Signature.getInstance("RSASSA-PSS", provider);
+                }
+                try {
+                    sig.setParameter(getPSSParameterSpec());
+                } catch (InvalidAlgorithmParameterException e) {
+                    throw new NoSuchAlgorithmException("Should not happen", e);
+                }
+                return sig;
+            } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+                return super.getSignature(provider, algorithmID);
+            }
+        }
+
+        abstract PSSParameterSpec getPSSParameterSpec();
+    }
+
     /**
      * Class SignatureRSASHA1MGF1
      */
-    public static class SignatureRSASHA1MGF1 extends SignatureBaseRSA {
+    public static class SignatureRSASHA1MGF1 extends SignatureBaseRSAPSS {
+
+        private static PSSParameterSpec spec
+                = new PSSParameterSpec("SHA-1", "MGF1", MGF1ParameterSpec.SHA1,
+                20, PSSParameterSpec.TRAILER_FIELD_BC);
 
         /**
          * Constructor SignatureRSASHA1MGF1
@@ -387,12 +435,21 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
         public String engineGetURI() {
             return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA1_MGF1;
         }
+
+        @Override
+        public PSSParameterSpec getPSSParameterSpec() {
+            return spec;
+        }
     }
 
     /**
      * Class SignatureRSASHA224MGF1
      */
-    public static class SignatureRSASHA224MGF1 extends SignatureBaseRSA {
+    public static class SignatureRSASHA224MGF1 extends SignatureBaseRSAPSS {
+
+        private static PSSParameterSpec spec
+                = new PSSParameterSpec("SHA-224", "MGF1", MGF1ParameterSpec.SHA224,
+                28, PSSParameterSpec.TRAILER_FIELD_BC);
 
         /**
          * Constructor SignatureRSASHA224MGF1
@@ -412,12 +469,21 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
         public String engineGetURI() {
             return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA224_MGF1;
         }
+
+        @Override
+        public PSSParameterSpec getPSSParameterSpec() {
+            return spec;
+        }
     }
 
     /**
      * Class SignatureRSASHA256MGF1
      */
-    public static class SignatureRSASHA256MGF1 extends SignatureBaseRSA {
+    public static class SignatureRSASHA256MGF1 extends SignatureBaseRSAPSS {
+
+        private static PSSParameterSpec spec
+                = new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256,
+                32, PSSParameterSpec.TRAILER_FIELD_BC);
 
         /**
          * Constructor SignatureRSASHA256MGF1
@@ -437,12 +503,21 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
         public String engineGetURI() {
             return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256_MGF1;
         }
+
+        @Override
+        public PSSParameterSpec getPSSParameterSpec() {
+            return spec;
+        }
     }
 
     /**
      * Class SignatureRSASHA384MGF1
      */
-    public static class SignatureRSASHA384MGF1 extends SignatureBaseRSA {
+    public static class SignatureRSASHA384MGF1 extends SignatureBaseRSAPSS {
+
+        private static PSSParameterSpec spec
+                = new PSSParameterSpec("SHA-384", "MGF1", MGF1ParameterSpec.SHA384,
+                48, PSSParameterSpec.TRAILER_FIELD_BC);
 
         /**
          * Constructor SignatureRSASHA384MGF1
@@ -462,12 +537,21 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
         public String engineGetURI() {
             return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA384_MGF1;
         }
+
+        @Override
+        public PSSParameterSpec getPSSParameterSpec() {
+            return spec;
+        }
     }
 
     /**
      * Class SignatureRSASHA512MGF1
      */
-    public static class SignatureRSASHA512MGF1 extends SignatureBaseRSA {
+    public static class SignatureRSASHA512MGF1 extends SignatureBaseRSAPSS {
+
+        private static PSSParameterSpec spec
+                = new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512,
+                64, PSSParameterSpec.TRAILER_FIELD_BC);
 
         /**
          * Constructor SignatureRSASHA512MGF1
@@ -487,12 +571,22 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
         public String engineGetURI() {
             return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA512_MGF1;
         }
+
+        @Override
+        public PSSParameterSpec getPSSParameterSpec() {
+            return spec;
+        }
     }
 
     /**
      * Class SignatureRSA3_SHA224MGF1
      */
-    public static class SignatureRSASHA3_224MGF1 extends SignatureBaseRSA {
+    public static class SignatureRSASHA3_224MGF1 extends SignatureBaseRSAPSS {
+
+        private static PSSParameterSpec spec
+                = new PSSParameterSpec("SHA3-224", "MGF1",
+                new MGF1ParameterSpec("SHA3-224"),
+                28, PSSParameterSpec.TRAILER_FIELD_BC);
 
         /**
          * Constructor SignatureRSASHA3_224MGF1
@@ -512,12 +606,22 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
         public String engineGetURI() {
             return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA3_224_MGF1;
         }
+
+        @Override
+        public PSSParameterSpec getPSSParameterSpec() {
+            return spec;
+        }
     }
 
     /**
      * Class SignatureRSA3_SHA256MGF1
      */
-    public static class SignatureRSASHA3_256MGF1 extends SignatureBaseRSA {
+    public static class SignatureRSASHA3_256MGF1 extends SignatureBaseRSAPSS {
+
+        private static PSSParameterSpec spec
+                = new PSSParameterSpec("SHA3-256", "MGF1",
+                new MGF1ParameterSpec("SHA3-256"),
+                32, PSSParameterSpec.TRAILER_FIELD_BC);
 
         /**
          * Constructor SignatureRSASHA3_256MGF1
@@ -537,12 +641,22 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
         public String engineGetURI() {
             return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA3_256_MGF1;
         }
+
+        @Override
+        public PSSParameterSpec getPSSParameterSpec() {
+            return spec;
+        }
     }
 
     /**
      * Class SignatureRSA3_SHA384MGF1
      */
-    public static class SignatureRSASHA3_384MGF1 extends SignatureBaseRSA {
+    public static class SignatureRSASHA3_384MGF1 extends SignatureBaseRSAPSS {
+
+        private static PSSParameterSpec spec
+                = new PSSParameterSpec("SHA3-384", "MGF1",
+                new MGF1ParameterSpec("SHA3-384"),
+                48, PSSParameterSpec.TRAILER_FIELD_BC);
 
         /**
          * Constructor SignatureRSASHA3_384MGF1
@@ -562,12 +676,22 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
         public String engineGetURI() {
             return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA3_384_MGF1;
         }
+
+        @Override
+        public PSSParameterSpec getPSSParameterSpec() {
+            return spec;
+        }
     }
 
     /**
      * Class SignatureRSASHA3_512MGF1
      */
-    public static class SignatureRSASHA3_512MGF1 extends SignatureBaseRSA {
+    public static class SignatureRSASHA3_512MGF1 extends SignatureBaseRSAPSS {
+
+        private static PSSParameterSpec spec
+                = new PSSParameterSpec("SHA3-512", "MGF1",
+                new MGF1ParameterSpec("SHA3-512"),
+                64, PSSParameterSpec.TRAILER_FIELD_BC);
 
         /**
          * Constructor SignatureRSASHA3_512MGF1
@@ -586,6 +710,11 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
         @Override
         public String engineGetURI() {
             return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA3_512_MGF1;
+        }
+
+        @Override
+        public PSSParameterSpec getPSSParameterSpec() {
+            return spec;
         }
     }
 

--- a/src/main/java/org/apache/xml/security/algorithms/implementations/SignatureBaseRSA.java
+++ b/src/main/java/org/apache/xml/security/algorithms/implementations/SignatureBaseRSA.java
@@ -413,7 +413,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
      */
     public static class SignatureRSASHA1MGF1 extends SignatureBaseRSAPSS {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA1_MGF1_PARAMS
                 = new PSSParameterSpec("SHA-1", "MGF1", MGF1ParameterSpec.SHA1,
                 20, PSSParameterSpec.TRAILER_FIELD_BC);
 
@@ -438,7 +438,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
 
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA1_MGF1_PARAMS;
         }
     }
 
@@ -447,7 +447,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
      */
     public static class SignatureRSASHA224MGF1 extends SignatureBaseRSAPSS {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA224_MGF1_PARAMS
                 = new PSSParameterSpec("SHA-224", "MGF1", MGF1ParameterSpec.SHA224,
                 28, PSSParameterSpec.TRAILER_FIELD_BC);
 
@@ -472,7 +472,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
 
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA224_MGF1_PARAMS;
         }
     }
 
@@ -481,7 +481,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
      */
     public static class SignatureRSASHA256MGF1 extends SignatureBaseRSAPSS {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA256_MGF1_PARAMS
                 = new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256,
                 32, PSSParameterSpec.TRAILER_FIELD_BC);
 
@@ -506,7 +506,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
 
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA256_MGF1_PARAMS;
         }
     }
 
@@ -515,7 +515,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
      */
     public static class SignatureRSASHA384MGF1 extends SignatureBaseRSAPSS {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA384_MGF1_PARAMS
                 = new PSSParameterSpec("SHA-384", "MGF1", MGF1ParameterSpec.SHA384,
                 48, PSSParameterSpec.TRAILER_FIELD_BC);
 
@@ -540,7 +540,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
 
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA384_MGF1_PARAMS;
         }
     }
 
@@ -549,7 +549,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
      */
     public static class SignatureRSASHA512MGF1 extends SignatureBaseRSAPSS {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA512_MGF1_PARAMS
                 = new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512,
                 64, PSSParameterSpec.TRAILER_FIELD_BC);
 
@@ -574,7 +574,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
 
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA512_MGF1_PARAMS;
         }
     }
 
@@ -583,7 +583,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
      */
     public static class SignatureRSASHA3_224MGF1 extends SignatureBaseRSAPSS {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA3_224_MGF1_PARAMS
                 = new PSSParameterSpec("SHA3-224", "MGF1",
                 new MGF1ParameterSpec("SHA3-224"),
                 28, PSSParameterSpec.TRAILER_FIELD_BC);
@@ -609,7 +609,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
 
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA3_224_MGF1_PARAMS;
         }
     }
 
@@ -618,7 +618,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
      */
     public static class SignatureRSASHA3_256MGF1 extends SignatureBaseRSAPSS {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA3_256_MGF1_PARAMS
                 = new PSSParameterSpec("SHA3-256", "MGF1",
                 new MGF1ParameterSpec("SHA3-256"),
                 32, PSSParameterSpec.TRAILER_FIELD_BC);
@@ -644,7 +644,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
 
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA3_256_MGF1_PARAMS;
         }
     }
 
@@ -653,7 +653,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
      */
     public static class SignatureRSASHA3_384MGF1 extends SignatureBaseRSAPSS {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA3_384_MGF1_PARAMS
                 = new PSSParameterSpec("SHA3-384", "MGF1",
                 new MGF1ParameterSpec("SHA3-384"),
                 48, PSSParameterSpec.TRAILER_FIELD_BC);
@@ -679,7 +679,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
 
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA3_384_MGF1_PARAMS;
         }
     }
 
@@ -688,7 +688,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
      */
     public static class SignatureRSASHA3_512MGF1 extends SignatureBaseRSAPSS {
 
-        private static PSSParameterSpec spec
+        private static final PSSParameterSpec SHA3_512_MGF1_PARAMS
                 = new PSSParameterSpec("SHA3-512", "MGF1",
                 new MGF1ParameterSpec("SHA3-512"),
                 64, PSSParameterSpec.TRAILER_FIELD_BC);
@@ -714,12 +714,12 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
 
         @Override
         public PSSParameterSpec getPSSParameterSpec() {
-            return spec;
+            return SHA3_512_MGF1_PARAMS;
         }
     }
 
     public static class SignatureRSASSAPSS extends SignatureBaseRSA {
-        PSSParameterSpec pssParameterSpec;
+        private PSSParameterSpec pssParameterSpec;
 
         public enum DigestAlgorithm {
             SHA256("SHA-256", "http://www.w3.org/2001/04/xmlenc#sha256", 32),

--- a/src/test/java/org/apache/xml/security/test/dom/algorithms/PKSignatureAlgorithmTest.java
+++ b/src/test/java/org/apache/xml/security/test/dom/algorithms/PKSignatureAlgorithmTest.java
@@ -58,6 +58,7 @@ class PKSignatureAlgorithmTest {
 
     private static KeyPair rsaKeyPair, ecKeyPair;
     private static boolean bcInstalled;
+    private static int javaVersion;
 
     static {
         org.apache.xml.security.Init.init();
@@ -82,6 +83,11 @@ class PKSignatureAlgorithmTest {
                 Security.insertProviderAt(provider, 2);
                 bcInstalled = true;
             }
+        }
+        try {
+            javaVersion = Integer.getInteger("java.specification.version", 0);
+        } catch (NumberFormatException ex) {
+            // ignore
         }
 
         KeyPairGenerator rsaKpg = KeyPairGenerator.getInstance("RSA");
@@ -198,8 +204,6 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_SHA1_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
-
         // Read in plaintext document
         Document document = XMLUtils.readResource("ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml",
             getClass().getClassLoader(), false);
@@ -214,8 +218,6 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_SHA224_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
-
         // Read in plaintext document
         Document document = XMLUtils.readResource("ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml",
             getClass().getClassLoader(), false);
@@ -230,8 +232,6 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_SHA256_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
-
         // Read in plaintext document
         Document document = XMLUtils.readResource("ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml",
             getClass().getClassLoader(), false);
@@ -246,8 +246,6 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_SHA384_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
-
         // Read in plaintext document
         Document document = XMLUtils.readResource("ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml",
             getClass().getClassLoader(), false);
@@ -262,8 +260,6 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_SHA512_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
-
         // Read in plaintext document
         Document document = XMLUtils.readResource("ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml",
             getClass().getClassLoader(), false);
@@ -278,7 +274,7 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_SHA3_224_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
+        Assumptions.assumeTrue(bcInstalled || javaVersion >=16);
 
         // Read in plaintext document
         Document document = XMLUtils.readResource("ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml",
@@ -294,7 +290,7 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_SHA3_256_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
+        Assumptions.assumeTrue(bcInstalled || javaVersion >=16);
 
         // Read in plaintext document
         Document document = XMLUtils.readResource("ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml",
@@ -310,7 +306,7 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_SHA3_384_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
+        Assumptions.assumeTrue(bcInstalled || javaVersion >=16);
 
         // Read in plaintext document
         Document document = XMLUtils.readResource("ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml",
@@ -326,7 +322,7 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_SHA3_512_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
+        Assumptions.assumeTrue(bcInstalled || javaVersion >=16);
 
         // Read in plaintext document
         Document document = XMLUtils.readResource("ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml",
@@ -342,7 +338,6 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_PSS() throws Exception {
-        Assumptions.assumeTrue(bcInstalled || TestUtils.isJava11Compatible());
         // Read in plaintext document
         Document document = XMLUtils.readResource("ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml",
             getClass().getClassLoader(), false);

--- a/src/test/java/org/apache/xml/security/test/javax/xml/crypto/dsig/PKSignatureAlgorithmTest.java
+++ b/src/test/java/org/apache/xml/security/test/javax/xml/crypto/dsig/PKSignatureAlgorithmTest.java
@@ -67,15 +67,19 @@ class PKSignatureAlgorithmTest {
     private final KeySelector kvks;
     private final CanonicalizationMethod withoutComments;
     private final DigestMethod sha1;
-    private final SignatureMethod rsaSha1, rsaSha224, rsaSha256, rsaSha384, rsaSha512, rsaRipemd160;
-    private final SignatureMethod rsaSha1Mgf1, rsaSha224Mgf1, rsaSha256Mgf1, rsaSha384Mgf1, rsaSha512Mgf1, rsaPss, rsaPssSha512;
-    private final SignatureMethod ecdsaSha1, ecdsaSha224, ecdsaSha256, ecdsaSha384, ecdsaSha512, ecdsaRipemd160;
+    private final SignatureMethod rsaSha1, rsaSha224, rsaSha256, rsaSha384,
+            rsaSha512, rsaRipemd160;
+    private final SignatureMethod rsaSha1Mgf1, rsaSha224Mgf1, rsaSha256Mgf1,
+            rsaSha384Mgf1, rsaSha512Mgf1, rsaSha3_224Mgf1, rsaSha3_256Mgf1,
+            rsaSha3_384Mgf1, rsaSha3_512Mgf1, rsaPss, rsaPssSha512;
+    private final SignatureMethod ecdsaSha1, ecdsaSha224, ecdsaSha256,
+            ecdsaSha384, ecdsaSha512, ecdsaRipemd160;
     private final XMLSignatureFactory fac;
     private final KeyPair rsaKeyPair, ecKeyPair;
     private final KeyInfo rsaki;
     private KeyInfo ecki;
     private boolean ecAlgParamsSupport = true;
-    private final boolean isJDK11;
+    private static int javaVersion;
     private static boolean bcInstalled;
 
     static {
@@ -102,6 +106,11 @@ class PKSignatureAlgorithmTest {
                 Security.insertProviderAt(provider, 2);
                 bcInstalled = true;
             }
+        }
+        try {
+            javaVersion = Integer.getInteger("java.specification.version", 0);
+        } catch (NumberFormatException ex) {
+            // ignore
         }
     }
 
@@ -135,6 +144,10 @@ class PKSignatureAlgorithmTest {
         rsaSha256Mgf1 = fac.newSignatureMethod("http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1", null);
         rsaSha384Mgf1 = fac.newSignatureMethod("http://www.w3.org/2007/05/xmldsig-more#sha384-rsa-MGF1", null);
         rsaSha512Mgf1 = fac.newSignatureMethod("http://www.w3.org/2007/05/xmldsig-more#sha512-rsa-MGF1", null);
+        rsaSha3_224Mgf1 = fac.newSignatureMethod("http://www.w3.org/2007/05/xmldsig-more#sha3-224-rsa-MGF1", null);
+        rsaSha3_256Mgf1 = fac.newSignatureMethod("http://www.w3.org/2007/05/xmldsig-more#sha3-256-rsa-MGF1", null);
+        rsaSha3_384Mgf1 = fac.newSignatureMethod("http://www.w3.org/2007/05/xmldsig-more#sha3-384-rsa-MGF1", null);
+        rsaSha3_512Mgf1 = fac.newSignatureMethod("http://www.w3.org/2007/05/xmldsig-more#sha3-512-rsa-MGF1", null);
         rsaPss = fac.newSignatureMethod("http://www.w3.org/2007/05/xmldsig-more#rsa-pss", null);
         RSAPSSParameterSpec params = new RSAPSSParameterSpec();
         params.setTrailerField(1);
@@ -168,7 +181,6 @@ class PKSignatureAlgorithmTest {
             ecki = kifac.newKeyInfo(Collections.singletonList
                                 (kifac.newKeyValue(ecKeyPair.getPublic())), "DSig.KeyInfo_1");
         }
-        isJDK11 = System.getProperty("java.version").startsWith("11");
     }
 
     @AfterAll
@@ -215,84 +227,105 @@ class PKSignatureAlgorithmTest {
 
     @Test
     void testRSA_SHA1_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
         test_create_signature_enveloping(rsaSha1Mgf1, sha1, rsaki,
                                          rsaKeyPair.getPrivate(), kvks);
     }
 
     @Test
     void testRSA_SHA224_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
         test_create_signature_enveloping(rsaSha224Mgf1, sha1, rsaki,
                                          rsaKeyPair.getPrivate(), kvks);
     }
 
     @Test
     void testRSA_SHA256_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
         test_create_signature_enveloping(rsaSha256Mgf1, sha1, rsaki,
                                          rsaKeyPair.getPrivate(), kvks);
     }
 
     @Test
     void testRSA_SHA384_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
         test_create_signature_enveloping(rsaSha384Mgf1, sha1, rsaki,
                                          rsaKeyPair.getPrivate(), kvks);
     }
 
     @Test
     void testRSA_SHA512_MGF1() throws Exception {
-        Assumptions.assumeTrue(bcInstalled);
         test_create_signature_enveloping(rsaSha512Mgf1, sha1, rsaki,
                                          rsaKeyPair.getPrivate(), kvks);
     }
 
     @Test
+    void testRSA_SHA3_224_MGF1() throws Exception {
+        Assumptions.assumeTrue(bcInstalled || javaVersion >= 16);
+        test_create_signature_enveloping(rsaSha3_224Mgf1, sha1, rsaki,
+                                         rsaKeyPair.getPrivate(), kvks);
+    }
+
+    @Test
+    void testRSA_SHA3_256_MGF1() throws Exception {
+        Assumptions.assumeTrue(bcInstalled || javaVersion >= 16);
+        test_create_signature_enveloping(rsaSha3_256Mgf1, sha1, rsaki,
+                                         rsaKeyPair.getPrivate(), kvks);
+    }
+
+    @Test
+    void testRSA_SHA3_384_MGF1() throws Exception {
+        Assumptions.assumeTrue(bcInstalled || javaVersion >= 16);
+        test_create_signature_enveloping(rsaSha3_384Mgf1, sha1, rsaki,
+                                         rsaKeyPair.getPrivate(), kvks);
+    }
+
+    @Test
+    void testRSA_SHA3_512_MGF1() throws Exception {
+        Assumptions.assumeTrue(bcInstalled || javaVersion >= 16);
+        test_create_signature_enveloping(rsaSha3_512Mgf1, sha1, rsaki,
+                                         rsaKeyPair.getPrivate(), kvks);
+    }
+
+    @Test
     void testRSA_PSS() throws Exception {
-        Assumptions.assumeTrue(bcInstalled || org.apache.xml.security.test.dom.TestUtils.isJava11Compatible());
         test_create_signature_enveloping(rsaPss, sha1, rsaki,
                 rsaKeyPair.getPrivate(), kvks);
     }
 
     @Test
     void testRSA_PSS_SHA512() throws Exception {
-        Assumptions.assumeTrue(bcInstalled || org.apache.xml.security.test.dom.TestUtils.isJava11Compatible());
         test_create_signature_enveloping(rsaPssSha512, sha1, rsaki,
                 rsaKeyPair.getPrivate(), kvks);
     }
 
     @Test
     void testECDSA_SHA1() throws Exception {
-        Assumptions.assumeTrue(ecAlgParamsSupport && ecki != null && !isJDK11);
+        Assumptions.assumeTrue(ecAlgParamsSupport && ecki != null && javaVersion != 11);
         test_create_signature_enveloping(ecdsaSha1, sha1, ecki,
                                          ecKeyPair.getPrivate(), kvks);
     }
 
     @Test
     void testECDSA_SHA224() throws Exception {
-        Assumptions.assumeTrue(ecAlgParamsSupport && ecki != null && !isJDK11);
+        Assumptions.assumeTrue(ecAlgParamsSupport && ecki != null && javaVersion != 11);
         test_create_signature_enveloping(ecdsaSha224, sha1, ecki,
                                          ecKeyPair.getPrivate(), kvks);
     }
 
     @Test
     void testECDSA_SHA256() throws Exception {
-        Assumptions.assumeTrue(ecAlgParamsSupport && ecki != null && !isJDK11);
+        Assumptions.assumeTrue(ecAlgParamsSupport && ecki != null && javaVersion != 11);
         test_create_signature_enveloping(ecdsaSha256, sha1, ecki,
                                          ecKeyPair.getPrivate(), kvks);
     }
 
     @Test
     void testECDSA_SHA384() throws Exception {
-        Assumptions.assumeTrue(ecAlgParamsSupport && ecki != null && !isJDK11);
+        Assumptions.assumeTrue(ecAlgParamsSupport && ecki != null && javaVersion != 11);
         test_create_signature_enveloping(ecdsaSha384, sha1, ecki,
                                          ecKeyPair.getPrivate(), kvks);
     }
 
     @Test
     void testECDSA_SHA512() throws Exception {
-        Assumptions.assumeTrue(ecAlgParamsSupport && ecki != null && !isJDK11);
+        Assumptions.assumeTrue(ecAlgParamsSupport && ecki != null && javaVersion != 11);
         test_create_signature_enveloping(ecdsaSha512, sha1, ecki,
                                          ecKeyPair.getPrivate(), kvks);
     }


### PR DESCRIPTION
This change includes more portable support for the RSSSA-PSS algorithms without parameters defined in RFC 9231. 

It instantiates java.security.Signature objects with an "RSASSA-PSS" algorithm and initializes the default parameters using a `PSSParameterSpec` object. This approach works for both the JDK and BouncyCastle JCE providers. 

If this approach does not work for some reason, it falls back to instantiating Signature objects using algorithms like "SHA256withRSAandMGF1" (however these algorithm names are not standard as per the Java Security Standard Algorithm Names specification, so may not work for certain JCE providers, such as the ones in the JDK).