### PR TITLE
Update protectAgainstWrappingAttackNodeWrapping for proxy elements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -562,6 +562,12 @@
                      <version>2.3.3</version>
                      <scope>test</scope>
                  </dependency>
+                 <dependency>
+                     <groupId>com.sun.xml.messaging.saaj</groupId>
+                     <artifactId>saaj-impl</artifactId>
+                     <version>1.5.3</version>
+                     <scope>test</scope>
+                 </dependency>
              </dependencies>
          </profile>
 

--- a/src/main/java/org/apache/xml/security/utils/XMLUtils.java
+++ b/src/main/java/org/apache/xml/security/utils/XMLUtils.java
@@ -931,7 +931,7 @@ public final class XMLUtils {
                     int length = attributes.getLength();
                     for (int i = 0; i < length; i++) {
                         Attr attr = (Attr)attributes.item(i);
-                        if (attr.isId() && id.equals(attr.getValue()) && se != knownElement) {
+                        if (attr.isId() && id.equals(attr.getValue()) && !knownElement.isSameNode(se)) {
                             LOG.warn("Multiple elements with the same 'Id' attribute value!");
                             return false;
                         }

--- a/src/test/java/org/apache/xml/security/utils/XMLUtilsTest.java
+++ b/src/test/java/org/apache/xml/security/utils/XMLUtilsTest.java
@@ -1,0 +1,56 @@
+package org.apache.xml.security.utils;
+
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+
+import javax.xml.namespace.QName;
+import javax.xml.soap.*;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class XMLUtilsTest {
+
+    @Test
+    void protectAgainstWrappingAttackNodeWrappingOK() throws SOAPException {
+
+        String elementId = "test:identifier";
+        String serviceNS = "http://test-service";
+        String elementWithUniqueId = "ElementWithUniqueId";
+
+        SOAPMessage message = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL).createMessage();
+        Element documentElement = message.getSOAPPart().getDocumentElement();
+
+        SOAPHeaderElement soapHeader = message.getSOAPHeader().addHeaderElement(new QName(serviceNS, elementWithUniqueId));
+        soapHeader.setAttributeNS(null, "id", elementId);
+        soapHeader.setIdAttribute("id", true);
+
+        boolean result = XMLUtils.protectAgainstWrappingAttack(documentElement, soapHeader, elementId);
+        assertTrue(result);
+    }
+
+
+    @Test
+    void protectAgainstWrappingAttackNodeWrappingFalse() throws SOAPException {
+
+        String elementId = "test:identifier";
+        String serviceNS = "http://test-service";
+        String elementWithId = "ElementWithId";
+        String elementWithDuplicateId = "ElementWithDuplicateId";
+
+        SOAPMessage message = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL).createMessage();
+        Element documentElement = message.getSOAPPart().getDocumentElement();
+
+        SOAPHeaderElement soapHeader = message.getSOAPHeader().addHeaderElement(new QName(serviceNS, elementWithId));
+        soapHeader.setAttributeNS(null, "id", elementId);
+        soapHeader.setIdAttribute("id", true);
+
+        SOAPHeaderElement soapHeaderDuplicate = message.getSOAPHeader().addHeaderElement(new QName(serviceNS, elementWithDuplicateId));
+        soapHeaderDuplicate.setAttributeNS(null, "id", elementId);
+        soapHeaderDuplicate.setIdAttribute("id", true);
+
+        boolean result = XMLUtils.protectAgainstWrappingAttack(documentElement, soapHeader, elementId);
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
Some specific XML DOM handling implementations are using proxy approach on top of pure DOM implementation, such as: 
com.sun.xml.messaging.saaj:saaj-impl:1.5.3
Where HeaderElement1_2Impl is used on top of the dom structure  element com.sun.org.apache.xerces.internal.dom.ElementNSImpl.

This PR is small update to support also the proxy-element usage for  WrappingAttackNodeWrapping.  

