### PR TITLE
Remove call to Signature.getProvider() in debug log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
           --add-exports org.apache.santuario.xmlsec/org.apache.xml.security.test.dom.utils.jmh_generated=ALL-UNNAMED
           --add-exports org.apache.santuario.xmlsec/org.apache.xml.security.test.dom.xalan=ALL-UNNAMED
           --add-exports org.apache.santuario.xmlsec/org.apache.xml.security.test.stax.performance.jmh_generated=ALL-UNNAMED
+          --add-opens org.apache.santuario.xmlsec/org.apache.xml.security.test.dom.providers=java.base
         </maven.test.argLine>
         <skipUT>false</skipUT>
         <skipIT>true</skipIT>

--- a/src/main/java/org/apache/xml/security/algorithms/implementations/SignatureBaseRSA.java
+++ b/src/main/java/org/apache/xml/security/algorithms/implementations/SignatureBaseRSA.java
@@ -61,8 +61,7 @@ public abstract class SignatureBaseRSA extends SignatureAlgorithmSpi {
     public SignatureBaseRSA(Provider provider) throws XMLSignatureException {
         String algorithmID = JCEMapper.translateURItoJCEID(this.engineGetURI());
         this.signatureAlgorithm = getSignature(provider, algorithmID);
-        LOG.log(Level.DEBUG, "Created SignatureRSA using {0} and provider {1}",
-            algorithmID, signatureAlgorithm.getProvider());
+        LOG.log(Level.DEBUG, "Created SignatureRSA using {0}", algorithmID);
     }
 
     Signature getSignature(Provider provider, String algorithmID)

--- a/src/test/java/org/apache/xml/security/test/dom/providers/TestCustomSignatureSpi.java
+++ b/src/test/java/org/apache/xml/security/test/dom/providers/TestCustomSignatureSpi.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright
+ * ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package org.apache.xml.security.test.dom.providers;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.security.InvalidKeyException;
+import java.security.InvalidParameterException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.security.SignatureSpi;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A fake custom SignatureSpi implementation to make sure Custom SignatureSpis are honored
+ */
+public class TestCustomSignatureSpi extends SignatureSpi {
+
+    private static AtomicInteger signCallCount = new AtomicInteger(0);
+    private static AtomicInteger verifyCallCount = new AtomicInteger(0);
+
+    private static PrivateKey privateKeyCaptured = null;
+
+    public static void reset() {
+        signCallCount.set(0);
+        verifyCallCount.set(0);
+        privateKeyCaptured = null;
+    }
+
+    public static void verifyCalls() {
+        assertNotNull(privateKeyCaptured, "engineInitSign not invoked");
+        if (signCallCount.get() == 0) {
+            fail("sign was not invoked");
+        }
+        if (verifyCallCount.get() == 0) {
+            fail("verify was not invoked");
+        }
+    }
+
+    @Override
+    protected void engineInitVerify(PublicKey publicKey) throws InvalidKeyException {
+
+    }
+
+    @Override
+    protected void engineInitSign(PrivateKey privateKey) throws InvalidKeyException {
+        if (privateKeyCaptured == null) {
+            privateKeyCaptured = privateKey;
+        }
+    }
+
+    @Override
+    protected void engineUpdate(byte b) throws SignatureException {
+
+    }
+
+    @Override
+    protected void engineUpdate(byte[] b, int off, int len) throws SignatureException {
+
+    }
+
+    @Override
+    protected byte[] engineSign() throws SignatureException {
+        if (signCallCount.incrementAndGet() != 1) {
+            fail("engineSign called multiple times");
+        }
+        return new byte[0];
+    }
+
+    @Override
+    protected boolean engineVerify(byte[] sigBytes) throws SignatureException {
+        verifyCallCount.incrementAndGet();
+        return true;
+    }
+
+    @Override
+    protected void engineSetParameter(String param, Object value) throws InvalidParameterException {
+
+    }
+
+    @Override
+    protected Object engineGetParameter(String param) throws InvalidParameterException {
+        return null;
+    }
+}


### PR DESCRIPTION
The debug log message makes a call to Signature.getProvider() too early.    
This causes Signature.chooseFirstProvider() to be called which matches the first provider always rather than the correct provider based on PrivateKey.getAlgorithm() when there are multiple providers.   
This debug log was changed in this commit and introduced the issue: https://github.com/apache/santuario-xml-security-java/commit/1f4891867a938b29f2f1904be35b07d113d3eda9
Added unit test cases with fake provider