### PR TITLE
workaround source RB issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,23 @@
                             <regex>true</regex>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>types-workaround-xmldsig</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}/generated-sources/xjc/org/apache/xml/security/binding/xmldsig/PGPDataType.java</file>
+                            <replacements>
+                                <replacement>
+                                    <token>line (.+) of file:.+src/main/resources/(.+)</token>
+                                    <value>line $1 of file:src/main/resources/$2</value>
+                                </replacement>
+                            </replacements>
+                            <regex>true</regex>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
after #77 , one issue remains in 4.0.0 and 4.0.1: working directory is stored in generated source https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/santuario/xmlsec/README.md

doing the same workaround