### PR TITLE
SANTUARIO-610: Fix NullPointerException in XMLCipher with BC AES GCM

### DIFF
--- a/src/main/java/org/apache/xml/security/encryption/XMLCipher.java
+++ b/src/main/java/org/apache/xml/security/encryption/XMLCipher.java
@@ -1150,7 +1150,9 @@ public final class XMLCipher {
                 try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
                     while ((numBytes = serializedData.read(buf)) != -1) {
                         byte[] data = c.update(buf, 0, numBytes);
-                        baos.write(data);
+                        if (data != null) {
+                            baos.write(data);
+                        }
                     }
                     baos.write(c.doFinal());
                     encryptedBytes = baos.toByteArray();

--- a/src/test/java/org/apache/xml/security/test/dom/encryption/XMLCipherTest.java
+++ b/src/test/java/org/apache/xml/security/test/dom/encryption/XMLCipherTest.java
@@ -75,6 +75,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1010,6 +1011,44 @@ class XMLCipherTest {
         Element encryptedData = (Element) encrypted.getElementsByTagNameNS(EncryptionConstants.EncryptionSpecNS, EncryptionConstants._TAG_ENCRYPTEDDATA).item(0);
 
         xmlCipher.decryptToByteArray(encryptedData);
+    }
+
+    @Test
+    void testEncryptForDataExceeding8192bytes() throws Exception {
+        boolean bcAtFirstPosition = false;
+        if (Security.getProvider("BC") == null) {
+            // Use reflection to add new BouncyCastleProvider
+            try {
+                Class<?> bouncyCastleProviderClass = Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider");
+                Provider bouncyCastleProvider = (Provider)bouncyCastleProviderClass.getConstructor().newInstance();
+                Security.insertProviderAt(bouncyCastleProvider, 1);
+                bcAtFirstPosition = true;
+            } catch (ReflectiveOperationException e) {
+                // BouncyCastle not installed, ignore
+            }
+        }
+        Assumptions.assumeTrue(bcAtFirstPosition);
+
+        KeyGenerator generator = KeyGenerator.getInstance("AES", "BC");
+        generator.init(128);
+        SecretKey key = generator.generateKey();
+
+        XMLCipher cipher = XMLCipher.getInstance(XMLCipher.AES_128_GCM);
+        cipher.init(XMLCipher.ENCRYPT_MODE, key);
+
+        Document document = document();
+        byte[] dataToEncrypt = new byte[8193];
+        for (int i = 0; i < 8193; i++) {
+            dataToEncrypt[i] = (byte) i;
+        }
+        EncryptedData encryptedData = cipher.encryptData(document, null, new ByteArrayInputStream(dataToEncrypt));
+
+        XMLCipher decipher = XMLCipher.getInstance(XMLCipher.AES_128);
+        decipher.init(XMLCipher.DECRYPT_MODE, key);
+        String algorithm = encryptedData.getEncryptionMethod().getAlgorithm();
+        assertEquals(XMLCipher.AES_128_GCM, algorithm);
+        byte[] decryptedByteArray = decipher.decryptToByteArray(decipher.martial(encryptedData));
+        assertArrayEquals(dataToEncrypt, decryptedByteArray);
     }
 
     @Test


### PR DESCRIPTION
Proposed a fix for SANTUARIO-610 when BouncyCastle is at first position in Java security providers and AES GCM NoPadding is used.

When run with BouncyCastle in test class path the code is executed correctly, but fails when `if (data != null)` is removed from `XMLCipher`.

Execute with `bouncycastle` profile
```shell
mvn test -Dtest=org.apache.xml.security.test.dom.encryption.XMLCipherTest -P bouncycastle
```