### PR TITLE
[SANTUARIO-613] Remove DH KeyType from the KeyUtils.KeyType enumeration

### DIFF
--- a/src/main/java/org/apache/xml/security/utils/KeyUtils.java
+++ b/src/main/java/org/apache/xml/security/utils/KeyUtils.java
@@ -76,7 +76,6 @@ public class KeyUtils {
         DSA("DSA", "RFC 8017", KeyAlgorithmType.DSA, "1.2.840.10040.4.1"),
         RSA("RSA", "RFC 8017", KeyAlgorithmType.RSA, "1.2.840.113549.1.1.1"),
         RSASSA_PSS("RSASSA-PSS", "RFC 3447", KeyAlgorithmType.RSASSA_PSS, "1.2.840.113549.1.1.10"),
-        DH("DH", "PKCS #3", KeyAlgorithmType.DH, "1.2.840.113549.1.3.1"),
         SECT163K1("sect163k1", "NIST K-163", KeyAlgorithmType.EC, "1.3.132.0.1"),
         SECT163R1("sect163r1", "", KeyAlgorithmType.EC, "1.3.132.0.2"),
         SECT163R2("sect163r2", "NIST B-163", KeyAlgorithmType.EC, "1.3.132.0.15"),


### PR DESCRIPTION
Remove DH KeyType from the KeyUtils.KeyType enumeration. For details see the:
https://issues.apache.org/jira/browse/SANTUARIO-613
and 
https://github.com/apache/santuario-xml-security-java/pull/293