### PR TITLE
[SANTUARIO-617] remove mgf element in case of rsa-oaep-mgf1p

### DIFF
--- a/src/main/java/org/apache/xml/security/encryption/XMLCipher.java
+++ b/src/main/java/org/apache/xml/security/encryption/XMLCipher.java
@@ -3201,7 +3201,8 @@ public final class XMLCipher {
                     );
                     result.appendChild(digestElement);
                 }
-                if (mgfAlgorithm != null) {
+
+                if (mgfAlgorithm != null && !XMLCipher.RSA_OAEP.equals(algorithm)) {
                     Element mgfElement =
                         XMLUtils.createElementInEncryption11Space(
                             contextDocument, EncryptionConstants._TAG_MGF

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLEncryptOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLEncryptOutputProcessor.java
@@ -154,7 +154,9 @@ public class XMLEncryptOutputProcessor extends AbstractEncryptOutputProcessor {
                         createStartElementAndOutputAsEvent(outputProcessorChain, XMLSecurityConstants.TAG_xenc_EncryptionMethod, false, attributes);
 
                         final String encryptionKeyTransportDigestAlgorithm = getSecurityProperties().getEncryptionKeyTransportDigestAlgorithm();
-                        final String encryptionKeyTransportMGFAlgorithm = getSecurityProperties().getEncryptionKeyTransportMGFAlgorithm();
+                        // Check for rsa-oaep-mgf1p then MGF1 is set by default and encryptionKeyTransportMGFAlgorithm must not be set!
+                        final String encryptionKeyTransportMGFAlgorithm = XMLSecurityConstants.NS_XENC_RSAOAEPMGF1P.equals(encryptionKeyTransportAlgorithm)?
+                                null : getSecurityProperties().getEncryptionKeyTransportMGFAlgorithm();
 
                         if (XMLSecurityConstants.NS_XENC11_RSAOAEP.equals(encryptionKeyTransportAlgorithm) ||
                                 XMLSecurityConstants.NS_XENC_RSAOAEPMGF1P.equals(encryptionKeyTransportAlgorithm)) {
@@ -214,7 +216,9 @@ public class XMLEncryptOutputProcessor extends AbstractEncryptOutputProcessor {
                                 }
 
                                 MGF1ParameterSpec mgfParameterSpec = new MGF1ParameterSpec("SHA-1");
-                                if (encryptionKeyTransportMGFAlgorithm != null) {
+                                // Check for RSA-OAEP then MGF1 is set by default and value must not be set!
+                                if (encryptionKeyTransportMGFAlgorithm != null
+                                    && !XMLSecurityConstants.NS_XENC_RSAOAEPMGF1P.equals(encryptionKeyTransportAlgorithm)) {
                                     String jceMGFAlgorithm = JCEMapper.translateURItoJCEID(encryptionKeyTransportMGFAlgorithm);
                                     mgfParameterSpec = new MGF1ParameterSpec(jceMGFAlgorithm);
                                 }

--- a/src/test/java/org/apache/xml/security/test/dom/encryption/XMLCipherTest.java
+++ b/src/test/java/org/apache/xml/security/test/dom/encryption/XMLCipherTest.java
@@ -57,6 +57,7 @@ import org.apache.xml.security.encryption.params.KeyAgreementParameters;
 import org.apache.xml.security.encryption.params.KeyDerivationParameters;
 import org.apache.xml.security.keys.KeyInfo;
 import org.apache.xml.security.parser.XMLParserException;
+import org.apache.xml.security.stax.ext.XMLSecurityConstants;
 import org.apache.xml.security.test.dom.TestUtils;
 import org.apache.xml.security.testutils.JDKTestUtils;
 import org.apache.xml.security.testutils.KeyTestUtils;
@@ -68,6 +69,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
@@ -369,6 +371,60 @@ class XMLCipherTest {
 
         target = toString(dd);
         assertEquals(source, target);
+    }
+
+    /**
+     * The http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p identifier defines the
+     * mask generation function as the fixed value of MGF1 with SHA1. In this case
+     * the optional xenc11:MGF element of the xenc:EncryptionMethod element
+     * MUST NOT be provided. For the http://www.w3.org/2009/xmlenc11#rsa-oaep
+     * identifier, the mask generation function must be defined by the xenc11:MGF
+     * element.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p,,0",
+            "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p,'',0",
+            "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p, http://www.w3.org/2009/xmlenc11#mgf1sha1,0",
+            "http://www.w3.org/2009/xmlenc11#rsa-oaep, http://www.w3.org/2009/xmlenc11#mgf1sha1,1",
+            "http://www.w3.org/2009/xmlenc11#rsa-oaep, http://www.w3.org/2009/xmlenc11#mgf1sha256,1",
+            "http://www.w3.org/2009/xmlenc11#rsa-oaep, http://www.w3.org/2009/xmlenc11#mgf1sha224,1",
+            "http://www.w3.org/2009/xmlenc11#rsa-oaep, http://www.w3.org/2009/xmlenc11#mgf1sha384,1",
+            "http://www.w3.org/2009/xmlenc11#rsa-oaep, http://www.w3.org/2009/xmlenc11#mgf1sha512,1",
+    })
+    void testAES128ElementRsaOaepKWCipher(String keyWrapAlgorithmURI, String mgf1URI, int mgfElementCount) throws Exception {
+        // Skip test for IBM JDK
+        Assumptions.assumeTrue(haveISOPadding,
+                "Test testAES128ElementRsaOaepKWCipher was skipped as necessary algorithms not available!" );
+        // init parameters encrypted key object
+        int transportKeyBitLength = 128;
+
+        // prepare the test document
+        Document d = TestUtils.newDocument(); // source
+
+        // Generate test recipient key pair
+        KeyPairGenerator rsaKeygen = KeyPairGenerator.getInstance("RSA");
+        KeyPair kp = rsaKeygen.generateKeyPair();
+        PublicKey pub = kp.getPublic();
+
+        // Generate a traffic key
+        KeyGenerator keygen = KeyGenerator.getInstance("AES");
+        keygen.init(transportKeyBitLength);
+        Key ephemeralSymmetricKey = keygen.generateKey();
+
+        XMLCipher cipherEncKey = XMLCipher.getInstance(keyWrapAlgorithmURI);
+        cipherEncKey.init(XMLCipher.WRAP_MODE, pub);
+        cipherEncKey.setSecureValidation(true);
+        // encrypt transport key with KeyAgreement
+        EncryptedKey encryptedKey =  cipherEncKey.encryptKey(d, ephemeralSymmetricKey,mgf1URI,null);
+        Element enckeyDoc = cipherEncKey.martial(encryptedKey);
+
+        NodeList mfgElements = enckeyDoc.getElementsByTagNameNS(XMLSecurityConstants.NS_XMLENC11, EncryptionConstants._TAG_MGF);
+        assertEquals(mgfElementCount, mfgElements.getLength());
+        assertEquals(keyWrapAlgorithmURI, encryptedKey.getEncryptionMethod().getAlgorithm());
+        if (mgfElementCount > 0) {
+            assertEquals(mgf1URI, encryptedKey.getEncryptionMethod().getMGFAlgorithm());
+        }
     }
 
     /**


### PR DESCRIPTION
sanuario/xml library have several option to created DOM structure or to serialize EncryptionMethod as example:

XMLCipher.newEncryptionMethod(Element element) {
XMLCipher.EncryptionMethodImpl.getEncryptionMethod()).toElement()
AbstractInternalEncryptionOutputProcessor.createKeyInfoStructure
...

And some of them does not omit MGF element in case of "rsa-oaep-mgf1p"

The purpose of the PR is to add the missing checks and provide regression tests to verify that the MGF element is omitted in the case of "rsa-oaep-mgf1p

For details see the [SANTUARIO-617](https://issues.apache.org/jira/browse/SANTUARIO-617)