### PR TITLE
Fixed KeyValue construction for EC keys

### DIFF
--- a/src/main/java/org/apache/jcp/xml/dsig/internal/dom/DOMKeyValue.java
+++ b/src/main/java/org/apache/jcp/xml/dsig/internal/dom/DOMKeyValue.java
@@ -550,7 +550,7 @@ public abstract class DOMKeyValue<K extends PublicKey> extends DOMStructure impl
             DOMUtils.setAttribute(namedCurveElem, "URI", "urn:oid:" + oid);
             String qname = (prefix == null || prefix.length() == 0)
                        ? "xmlns" : "xmlns:" + prefix;
-            namedCurveElem.setAttributeNS("http://www.w3.org/2000/xmlns/",
+            ecKeyValueElem.setAttributeNS("http://www.w3.org/2000/xmlns/",
                                           qname, XMLDSIG_11_XMLNS);
             ecKeyValueElem.appendChild(namedCurveElem);
             String encoded = XMLUtils.encodeToString(ecPublicKey);


### PR DESCRIPTION
- The signature KeyValue construction was wrong when an EC key was used. The namespace was declared in the "NamedCurve" element instead of "ECKeyValue". See [https://www.w3.org/TR/xmldsig-core1/#sec-ECKeyValue](https://www.w3.org/TR/xmldsig-core1/#sec-ECKeyValue)
- This fix is needed in Apache Santuario 3.0.x too.
