### PR TITLE
[SANTUARIO-623] fix the transformation XPATH2 filtering.

### DIFF
--- a/src/main/java/org/apache/xml/security/signature/XMLSignatureByteInput.java
+++ b/src/main/java/org/apache/xml/security/signature/XMLSignatureByteInput.java
@@ -67,7 +67,11 @@ public class XMLSignatureByteInput extends XMLSignatureInput {
 
     @Override
     public void write(OutputStream outputStream, boolean c14n11) throws CanonicalizationException, IOException {
-        if (bytes == null || outputStream == getOutputStream()) {
+        if (outputStream == getOutputStream()) {
+            return;
+        }
+        if (bytes == null) {
+            canonicalize(outputStream, c14n11);
             return;
         }
         outputStream.write(bytes);

--- a/src/test/java/org/apache/xml/security/test/dom/TestUtils.java
+++ b/src/test/java/org/apache/xml/security/test/dom/TestUtils.java
@@ -21,9 +21,15 @@ package org.apache.xml.security.test.dom;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.xml.security.parser.XMLParserException;
 import org.apache.xml.security.utils.Constants;
+import org.apache.xml.security.utils.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class TestUtils {
 
@@ -70,6 +76,27 @@ public class TestUtils {
 
     public static Document newDocument() throws ParserConfigurationException {
         return DBF.newDocumentBuilder().newDocument();
+    }
+
+    /**
+     * Create a test method to read input XML Fragment bytes and return a Document with root element "ROOT".
+     * The XML fragment are wrapped in a "ROOT" element to make it a valid XML document.
+     *
+     * @param xmlFragment the XML fragment bytes
+     *                    (e.g. "<a>text 2</a><a><b>text 2</b></a>".getBytes())
+     * @return the Document with root element "ROOT"
+     */
+    public static Document xmlFragmentToDocument(byte[] xmlFragment) throws XMLParserException, IOException {
+        if (xmlFragment == null || xmlFragment.length == 0) {
+            throw new IllegalArgumentException("XML fragment cannot be null or empty");
+        }
+
+        String xml = new String(xmlFragment, StandardCharsets.UTF_8);
+        String xmlDocument = "<ROOT>" + xml + "</ROOT>";
+
+        try (ByteArrayInputStream is = new ByteArrayInputStream(xmlDocument.getBytes(StandardCharsets.UTF_8))) {
+            return XMLUtils.read(is, true);
+        }
     }
 
     public static boolean isJava11Compatible() {

--- a/src/test/java/org/apache/xml/security/test/dom/TestUtils.java
+++ b/src/test/java/org/apache/xml/security/test/dom/TestUtils.java
@@ -35,6 +35,8 @@ public class TestUtils {
 
     private static final DocumentBuilderFactory DBF = DocumentBuilderFactory.newInstance();
     private static final boolean isJava11Compatible;
+    // The class-path to test resources
+    private static final String RESOURCE_PATH = "/org/apache/xml/security/test/javax/xml/crypto/dsig/";
 
     static {
         DBF.setNamespaceAware(true);
@@ -97,6 +99,18 @@ public class TestUtils {
         try (ByteArrayInputStream is = new ByteArrayInputStream(xmlDocument.getBytes(StandardCharsets.UTF_8))) {
             return XMLUtils.read(is, true);
         }
+    }
+
+    /**
+     * Get a test document from a classpath resource.
+     * @param fileName the file name of the resource
+     * @return the Document
+     * @throws XMLParserException if an error occurs while parsing the XML document
+     */
+    public static Document getTestDocumentFromResource(String fileName) throws XMLParserException {
+        // read document from classpath resource
+        return XMLUtils.read(TestUtils.class
+                .getResourceAsStream(RESOURCE_PATH + fileName), true);
     }
 
     public static boolean isJava11Compatible() {

--- a/src/test/java/org/apache/xml/security/test/dom/transforms/implementations/Xpath2TransformationTest.java
+++ b/src/test/java/org/apache/xml/security/test/dom/transforms/implementations/Xpath2TransformationTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,22 +19,64 @@
 package org.apache.xml.security.test.dom.transforms.implementations;
 
 
-import java.io.ByteArrayInputStream;
-
 import org.apache.xml.security.Init;
 import org.apache.xml.security.signature.XMLSignature;
+import org.apache.xml.security.signature.XMLSignatureInput;
+import org.apache.xml.security.signature.XMLSignatureNodeInput;
+import org.apache.xml.security.testutils.Assertions;
+import org.apache.xml.security.test.dom.TestUtils;
+import org.apache.xml.security.transforms.Transforms;
+import org.apache.xml.security.transforms.params.XPath2FilterContainer;
 import org.apache.xml.security.utils.Constants;
 import org.apache.xml.security.utils.XMLUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.platform.commons.util.StringUtils;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * Tests the XPath2Transformation implementation
+ *
+ * @see <A HREF="http://www.w3.org/TR/xmldsig-filter2/">XPath Filter v2.0 (TR)</A>
+ */
 class Xpath2TransformationTest {
+    private static final String TEST_PARAM_LIST_SEPARATOR = ";";
+    private static final String TEST_PARAM_VALUE_SEPARATOR = "::";
 
     static {
         Init.init();
     }
+
+    // Example as defined in <A HREF="https://www.w3.org/TR/xmldsig-filter2/#sec-Examples">4. Examples of Signature Filter Transform Processing</A>
+    private static final String TEST_EXAMPLE_DOCUMENT =
+            "  <Document>\r\n" +
+                    "     <ToBeSigned>\r\n" +
+                    "       <!-- comment -->\r\n" +
+                    "       <Data />\r\n" +
+                    "       <NotToBeSigned>\r\n" +
+                    "         <ReallyToBeSigned>\r\n" +
+                    "           <!-- comment -->\r\n" +
+                    "           <Data />\r\n" +
+                    "         </ReallyToBeSigned>\r\n" +
+                    "       </NotToBeSigned>\r\n" +
+                    "     </ToBeSigned>\r\n" +
+                    "     <ToBeSigned>\r\n" +
+                    "       <Data />\r\n" +
+                    "       <NotToBeSigned>\r\n" +
+                    "         <Data />\r\n" +
+                    "       </NotToBeSigned>\r\n" +
+                    "     </ToBeSigned>\r\n" +
+                    "  </Document>";
 
     @Test
     void testXpath2Transform() throws Exception {
@@ -157,4 +199,74 @@ class Xpath2TransformationTest {
         }
     }
 
+    /**
+     * Test the XPath2FilterContainer implementation with the example from the specification
+     * <A HREF="https://www.w3.org/TR/xmldsig-filter2/#sec-Examples">4. Examples of Signature
+     * Filter Transform Processing</A>
+     *
+     * @param xPathFilter the filter configuration as a string. The parameter is a list of
+     *                    filters separated by ";" and each filter is a pair of filter type
+     *                    and xpath separated by "::"
+     * @param resultValidationXPath the expected nodes count for each xpath as a string.
+     *                              The parameter is a list of xpaths  separated by ";"
+     *                              and each xpath is a pair of xpath and expected
+     *                              node count separated by "::"
+     * @throws Exception if an error occurs while performing the transformation
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "intersect:://ToBeSigned, //ToBeSigned::2;//Data::4",
+            "intersect:://ToBeSigned;subtract:://NotToBeSigned, //ToBeSigned::2;//Data::2;//NotToBeSigned::0;//ReallyToBeSigned::0",
+            "intersect:://ToBeSigned;subtract:://NotToBeSigned;union:://ReallyToBeSigned, //ToBeSigned::2;//Data::3;//NotToBeSigned::0;//ReallyToBeSigned::1",
+    })
+    void testXPath2TransformExample(String xPathFilter, String resultValidationXPath) throws Exception {
+        Map<String, String> filterConfiguration = convertStringToMap(xPathFilter);
+        Map<String, String> assertNodeCountByXPaths = convertStringToMap(resultValidationXPath);
+
+        Document testDocument;
+        try (ByteArrayInputStream is = new ByteArrayInputStream(TEST_EXAMPLE_DOCUMENT.getBytes())) {
+            testDocument = XMLUtils.read(is, true);
+        }
+        // create Transform filter
+        // create string array of [][] of filterConfiguration
+        String[][] filterConfigurationArray = filterConfiguration.entrySet()
+                .stream()
+                .map(entry -> new String[]{entry.getKey(), entry.getValue()})
+                .toArray(String[][]::new);
+
+        NodeList xpathElements = XPath2FilterContainer.newInstances(testDocument, filterConfigurationArray);
+        Transforms transforms = new Transforms(testDocument);
+        transforms.addTransform(Transforms.TRANSFORM_XPATH2FILTER, xpathElements);
+
+        // when: perform transformation
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        XMLSignatureInput res = transforms.performTransforms(new XMLSignatureNodeInput(testDocument), os);
+
+        // then: validate the result
+        Document resultDocument = TestUtils.xmlFragmentToDocument(res.getBytes());
+        Assertions.assertNodeCountForXPath(resultDocument, assertNodeCountByXPaths);
+    }
+
+    /**
+     * Get map values from string where each entry is separated by "list separator" ';' and
+     * key and value are separated by "value separator": '::'
+     * @param input the input string to convert to map
+     *              (e.g. "intersect:://ToBeSigned;subtract:://NotToBeSigned")
+*    * @return the map of key value pairs.
+     */
+    private Map<String, String> convertStringToMap(String input) {
+        if (StringUtils.isBlank(input)) {
+            return Map.of();
+        }
+
+        String[] entries = input.split(TEST_PARAM_LIST_SEPARATOR);
+        Map<String, String> map = new HashMap<>();
+        for (String entry : entries) {
+            String[] parts = entry.split(TEST_PARAM_VALUE_SEPARATOR);
+            if (parts.length == 2) {
+                map.put(parts[0], parts[1]);
+            }
+        }
+        return map;
+    }
 }

--- a/src/test/java/org/apache/xml/security/test/dom/transforms/implementations/Xpath2TransformationTest.java
+++ b/src/test/java/org/apache/xml/security/test/dom/transforms/implementations/Xpath2TransformationTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -56,27 +56,6 @@ class Xpath2TransformationTest {
     static {
         Init.init();
     }
-
-    // Example as defined in <A HREF="https://www.w3.org/TR/xmldsig-filter2/#sec-Examples">4. Examples of Signature Filter Transform Processing</A>
-    private static final String TEST_EXAMPLE_DOCUMENT =
-            "  <Document>\r\n" +
-                    "     <ToBeSigned>\r\n" +
-                    "       <!-- comment -->\r\n" +
-                    "       <Data />\r\n" +
-                    "       <NotToBeSigned>\r\n" +
-                    "         <ReallyToBeSigned>\r\n" +
-                    "           <!-- comment -->\r\n" +
-                    "           <Data />\r\n" +
-                    "         </ReallyToBeSigned>\r\n" +
-                    "       </NotToBeSigned>\r\n" +
-                    "     </ToBeSigned>\r\n" +
-                    "     <ToBeSigned>\r\n" +
-                    "       <Data />\r\n" +
-                    "       <NotToBeSigned>\r\n" +
-                    "         <Data />\r\n" +
-                    "       </NotToBeSigned>\r\n" +
-                    "     </ToBeSigned>\r\n" +
-                    "  </Document>";
 
     @Test
     void testXpath2Transform() throws Exception {
@@ -223,10 +202,7 @@ class Xpath2TransformationTest {
         Map<String, String> filterConfiguration = convertStringToMap(xPathFilter);
         Map<String, String> assertNodeCountByXPaths = convertStringToMap(resultValidationXPath);
 
-        Document testDocument;
-        try (ByteArrayInputStream is = new ByteArrayInputStream(TEST_EXAMPLE_DOCUMENT.getBytes())) {
-            testDocument = XMLUtils.read(is, true);
-        }
+        Document testDocument =  TestUtils.getTestDocumentFromResource("input-santuario-623.xml");
         // create Transform filter
         // create string array of [][] of filterConfiguration
         String[][] filterConfigurationArray = filterConfiguration.entrySet()

--- a/src/test/java/org/apache/xml/security/testutils/Assertions.java
+++ b/src/test/java/org/apache/xml/security/testutils/Assertions.java
@@ -1,0 +1,52 @@
+package org.apache.xml.security.testutils;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@code Assertions} is a collection of utility methods that support asserting
+ * conditions in DOM structure testing.
+ *
+ */
+public class Assertions {
+
+    /**
+     * Asserts that document contains the expected number of nodes for the given XPaths.
+     * @param resultDocument the document to assert if it contains the expected number of nodes
+     * @param assertNodeCountByXPaths the map of XPaths as key  and the expected number of nodes as map value
+     * @throws XPathExpressionException if an error occurs while evaluating the XPath expression
+     * @throws AssertionError if the number of nodes for the given XPath does not match the expected number of nodes
+     */
+    public static void assertNodeCountForXPath(Document resultDocument, Map<String, String> assertNodeCountByXPaths) throws XPathExpressionException {
+
+        for (Map.Entry<String, String> entry : assertNodeCountByXPaths.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            assertNodeCountForXPath(resultDocument, key, Integer.parseInt(value));
+        }
+    }
+
+    //Method asserts that given XPATH returns the expected number of nodes
+
+    /**
+     * Asserts that the given document contains the expected number of nodes for the given XPath.
+     * @param doc the document to assert if it contains the expected number of nodes
+     * @param xpath the XPath string expression to evaluate
+     * @param expectedCount the expected number of nodes for the given XPath
+     * @throws XPathExpressionException if an error occurs while evaluating the XPath expression
+     * @throws AssertionError if the number of nodes for the given XPath does not match the expected number of nodes
+     */
+    public static void assertNodeCountForXPath(Document doc, String xpath, int expectedCount) throws XPathExpressionException {
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList nodes = (NodeList) xPath.evaluate(xpath, doc, XPathConstants.NODESET);
+        assertEquals(expectedCount, nodes.getLength(), "Node count for xpath [" + xpath + "] does not match");
+    }
+}

--- a/src/test/java/org/apache/xml/security/testutils/Assertions.java
+++ b/src/test/java/org/apache/xml/security/testutils/Assertions.java
@@ -1,3 +1,20 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 package org.apache.xml.security.testutils;
 
 import org.w3c.dom.Document;
@@ -14,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * {@code Assertions} is a collection of utility methods that support asserting
  * conditions in DOM structure testing.
- *
  */
 public class Assertions {
 

--- a/src/test/resources/org/apache/xml/security/test/javax/xml/crypto/dsig/input-santuario-623.xml
+++ b/src/test/resources/org/apache/xml/security/test/javax/xml/crypto/dsig/input-santuario-623.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<!-- Note: this file is used to test the Santuario XML Security library for the signature transformation
+ Example as defined in <A HREF="https://www.w3.org/TR/xmldsig-filter2/#sec-Examples">4. Examples of Signature Filter Transform Processing</A>
+-->
+<Document>
+    <ToBeSigned>
+        <!-- comment -->
+        <Data>Test data 1</Data>
+        <NotToBeSigned>
+            <ReallyToBeSigned>
+                <!-- comment -->
+                <Data>Test data 2</Data>
+            </ReallyToBeSigned>
+        </NotToBeSigned>
+    </ToBeSigned>
+    <ToBeSigned>
+        <Data>Test data 3</Data>
+        <NotToBeSigned>
+            <Data>Test data 4</Data>
+        </NotToBeSigned>
+    </ToBeSigned>
+</Document>


### PR DESCRIPTION
This is fix for the issue described in the  [SANTUARIO-623], 
The actual fix is just tin the update of the 

in the XMLSignatureByteInput

* [`src/main/java/org/apache/xml/security/signature/XMLSignatureByteInput.java`](diffhunk://#diff-a5bcc66029146d03000f20be4fff21e48e4751528c3c22f496c03d19d144c14bL70-R74): Refactored the `write` method to improve handling of null `bytes` and streamline output stream checks.
  
Everything else was added just to expand Test Coverage to cover the particular case.
