### PR TITLE
[SANTUARIO-622] XMLSignatureInput close input stream

### DIFF
--- a/src/main/java/org/apache/xml/security/signature/XMLSignatureInput.java
+++ b/src/main/java/org/apache/xml/security/signature/XMLSignatureInput.java
@@ -507,7 +507,6 @@ public class XMLSignatureInput {
                     diOs.write(buffer, 0, bytesread);
                 }
             } finally {
-                LOG.debug("Closing input stream after finished reading it");
                 // the stream is closed, and we can remove the inputOctetStreamProxy reference
                 this.inputOctetStreamProxy = null;
             }

--- a/src/main/java/org/apache/xml/security/signature/XMLSignatureInput.java
+++ b/src/main/java/org/apache/xml/security/signature/XMLSignatureInput.java
@@ -18,6 +18,7 @@
  */
 package org.apache.xml.security.signature;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -44,6 +45,8 @@ import org.w3c.dom.Node;
  * $todo$ check whether an XMLSignatureInput can be _both_, octet stream _and_ node set?
  */
 public class XMLSignatureInput {
+    private static final org.slf4j.Logger LOG =
+            org.slf4j.LoggerFactory.getLogger(XMLSignatureInput.class);
     /*
      * The XMLSignature Input can be either:
      *   A byteArray like with/or without InputStream.
@@ -499,13 +502,14 @@ public class XMLSignatureInput {
         } else {
             byte[] buffer = new byte[4 * 1024];
             int bytesread = 0;
-            try {
-                while ((bytesread = inputOctetStreamProxy.read(buffer)) != -1) {
+            try (BufferedInputStream bis = new BufferedInputStream(inputOctetStreamProxy)) {
+                while ((bytesread = bis.read(buffer)) != -1) {
                     diOs.write(buffer, 0, bytesread);
                 }
-            } catch (IOException ex) {
-                inputOctetStreamProxy.close();
-                throw ex;
+            } finally {
+                LOG.debug("Closing input stream after finished reading it");
+                // the stream is closed, and we can remove the inputOctetStreamProxy reference
+                this.inputOctetStreamProxy = null;
             }
         }
     }


### PR DESCRIPTION
This pull request includes Resource management enhancements of the inputOctetStreamProxy in the `XMLSignatureInput` class, to mitigate the issue described in  [SATUARIO-622].



* [`src/main/java/org/apache/xml/security/signature/XMLSignatureInput.java`](diffhunk://#diff-6d3709a5ea6ec527779c8766e2a086461d2ae16bf549f024ff0fbfd9886f4e41L502-R512): Modified the `updateOutputStream` method to use a `BufferedInputStream` for more efficient reading and added a debug log statement for when the input stream is closed. (`[src/main/java/org/apache/xml/security/signature/XMLSignatureInput.javaL502-R512](diffhunk://#diff-6d3709a5ea6ec527779c8766e2a086461d2ae16bf549f024ff0fbfd9886f4e41L502-R512)`)
* [`src/main/java/org/apache/xml/security/signature/XMLSignatureInput.java`](diffhunk://#diff-6d3709a5ea6ec527779c8766e2a086461d2ae16bf549f024ff0fbfd9886f4e41L502-R512): Ensured the input stream is properly closed and the `inputOctetStreamProxy` reference is removed after reading. (`[src/main/java/org/apache/xml/security/signature/XMLSignatureInput.javaL502-R512](diffhunk://#diff-6d3709a5ea6ec527779c8766e2a086461d2ae16bf549f024ff0fbfd9886f4e41L502-R512)`)

