### PR TITLE
[SANTUARIO-576] Fix saml validation with saaj 1.4+

### DIFF
--- a/src/main/java/org/apache/xml/security/c14n/implementations/CanonicalizerBase.java
+++ b/src/main/java/org/apache/xml/security/c14n/implementations/CanonicalizerBase.java
@@ -241,7 +241,7 @@ public abstract class CanonicalizerBase extends CanonicalizerSpi {
 
             case Node.ELEMENT_NODE :
                 documentLevel = NODE_NOT_BEFORE_OR_AFTER_DOCUMENT_ELEMENT;
-                if (currentNode == excludeNode) {
+                if (excludeNode != null && (excludeNode.isSameNode(currentNode) || currentNode.isSameNode(excludeNode))) {
                     break;
                 }
                 Element currentElement = (Element)currentNode;

--- a/src/main/java/org/apache/xml/security/c14n/implementations/CanonicalizerBase.java
+++ b/src/main/java/org/apache/xml/security/c14n/implementations/CanonicalizerBase.java
@@ -241,7 +241,7 @@ public abstract class CanonicalizerBase extends CanonicalizerSpi {
 
             case Node.ELEMENT_NODE :
                 documentLevel = NODE_NOT_BEFORE_OR_AFTER_DOCUMENT_ELEMENT;
-                if (excludeNode != null && (excludeNode.isSameNode(currentNode) || currentNode.isSameNode(excludeNode))) {
+                if (currentNode == excludeNode || (excludeNode != null && (excludeNode.isSameNode(currentNode) || currentNode.isSameNode(excludeNode)))) {
                     break;
                 }
                 Element currentElement = (Element)currentNode;


### PR DESCRIPTION
When using SAAJ versions from 1.4 onwards, the signature element of the request was not removed due to type mismatch. This led to failed validations because the digest was wrongly calculated.
With this fix the excludeNode will be excluded even if the currentNode and excludeNode differ in type (e.g. com.sun.xml.messaging.saaj.soap.impl.ElementImpl vs. com.sun.org.apache.xerces.internal.dom.ElementNSImpl).