### PR TITLE
[SANTUARIO-625] Security warning is always logged when using ECDH with AES-KW

### DIFF
--- a/src/main/java/org/apache/xml/security/utils/KeyUtils.java
+++ b/src/main/java/org/apache/xml/security/utils/KeyUtils.java
@@ -208,13 +208,9 @@ public class KeyUtils {
             PublicKey publicKey = parameterSpec.getAgreementPublicKey();
             PrivateKey privateKey = parameterSpec.getAgreementPrivateKey();
 
-            String algorithm = publicKey.getAlgorithm();
-            if ("EC".equalsIgnoreCase(algorithm)) {
-                LOG.warn("EC keys are detected for key agreement algorithm! " +
-                        "Cryptographic algorithm may not be secure, consider using a different algorithm (and keys).");
-            }
-            algorithm = algorithm + (algorithm.equalsIgnoreCase("EC") ? "DH" : "");
-            KeyAgreement keyAgreement = KeyAgreement.getInstance(algorithm);
+            String keyAlgorithm = publicKey.getAlgorithm();
+            String keyAgreementAlgorithm = keyAlgorithm + ("EC".equalsIgnoreCase(keyAlgorithm) ? "DH" : "");
+            KeyAgreement keyAgreement = KeyAgreement.getInstance(keyAgreementAlgorithm);
             keyAgreement.init(privateKey);
             keyAgreement.doPhase(publicKey, true);
             byte[] secret = keyAgreement.generateSecret();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SANTUARIO-625