### PR TITLE
Fixed exception expectation in testDeeplyNestedElements

### DIFF
--- a/src/test/java/org/apache/xml/security/test/dom/parser/XMLParserEdgeCasesTest.java
+++ b/src/test/java/org/apache/xml/security/test/dom/parser/XMLParserEdgeCasesTest.java
@@ -22,6 +22,7 @@ import org.apache.xml.security.parser.XMLParserException;
 import org.apache.xml.security.utils.XMLUtils;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
+import org.xml.sax.SAXParseException;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -153,10 +154,15 @@ class XMLParserEdgeCasesTest {
             try {
                 XMLUtils.read(bais, false);
             } catch (XMLParserException e) {
-                // Stack overflow protection is acceptable
-                assertTrue(e.getMessage().contains("depth") || 
-                          e.getMessage().contains("stack") ||
-                          e.getMessage().contains("nested"),
+                /*
+                 * Stack overflow protection is acceptable - in this case there will be a parent
+                 * SAXParseException with a specific text.
+                 */
+                assertTrue(e.getCause() instanceof SAXParseException);
+                SAXParseException saxEx = (SAXParseException) e.getCause();
+                assertTrue(saxEx.getMessage().contains("depth") ||
+                          saxEx.getMessage().contains("stack") ||
+                          saxEx.getMessage().contains("nested"),
                           "Deep nesting should trigger protection");
             }
         }, "Parser should handle deep nesting gracefully");


### PR DESCRIPTION
Fixes the test for recent Java versions.

The test has two success paths:
1. Overflow limit is not hit, exception is not thrown.
2. Exception is thrown and it contains specific text, indicating that overflow protection is triggered.

Depth limit in java.xml is set by `jdk.xml.maxElementDepth` system property.
Default value [was changed](https://github.com/openjdk/jdk/commit/313bc7f64f69d8f352d495d2c35bea62aca910e4#diff-300c011df3fd1eb530bee91a74ce1d00b51502272310a32c6bf673ae298817a1R150) from `0` (non-limit) to `100` since jdk-19+16
So, in recent Java versions, the second path is triggered, however the check of the exception object is incorrect.

Original `SAXParseException` with specific text is wrapped into `XMLParserException` with a different message at XMLParserImpl:73

https://github.com/apache/santuario-xml-security-java/blob/d5dd9fea287153cfd74fa1c2b8a700d9e4d15201/src/main/java/org/apache/xml/security/parser/XMLParserImpl.java#L73

So the test needs to check the type and the message of the cause exception.