### PR TITLE
Fixed testAllZerosSignatureRejected - explicit key length

### DIFF
--- a/src/test/java/org/apache/xml/security/test/dom/algorithms/CryptographicEdgeCasesTest.java
+++ b/src/test/java/org/apache/xml/security/test/dom/algorithms/CryptographicEdgeCasesTest.java
@@ -75,6 +75,7 @@ class CryptographicEdgeCasesTest {
         SignatureAlgorithm sa = new SignatureAlgorithm(doc, XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256);
         
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
         KeyPair keyPair = keyPairGenerator.generateKeyPair();
         
         // Initialize verification


### PR DESCRIPTION
This makes the test compatible with recent Java versions.

The test relied on default RSA key length, which [was changed](https://github.com/openjdk/jdk/commit/313bc7f64f69d8f352d495d2c35bea62aca910e4#diff-300c011df3fd1eb530bee91a74ce1d00b51502272310a32c6bf673ae298817a1R150) from 2048 to 3072 since jdk-19+16